### PR TITLE
Make source tarballs in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,23 @@
 sudo: required
 env:
     matrix:
-    - IMAGE=centos:centos6 COMPONENTS=udt,myproxy,ssh
-    - IMAGE=centos:centos7 COMPONENTS=udt,myproxy,ssh
+    - IMAGE=centos:centos6 TASK=tests COMPONENTS=udt,myproxy,ssh
+    - IMAGE=centos:centos7 TASK=tests COMPONENTS=udt,myproxy,ssh
 #   Fedora builds are implemented but are disabled until we decide we
 #   need them; Travis limits our number of concurrent jobs so we don't
 #   want more than are necessary.
-#    - IMAGE=fedora:25      COMPONENTS=udt,myproxy,ssh
-#    - IMAGE=fedora:26      COMPONENTS=udt,myproxy,ssh
-#    - IMAGE=fedora:27      COMPONENTS=udt,myproxy,ssh
-    - IMAGE=centos:centos6 COMPONENTS=gram5
-    - IMAGE=centos:centos7 COMPONENTS=gram5
+#    - IMAGE=fedora:25     TASK=tests COMPONENTS=udt,myproxy,ssh
+#    - IMAGE=fedora:26     TASK=tests COMPONENTS=udt,myproxy,ssh
+#    - IMAGE=fedora:27     TASK=tests COMPONENTS=udt,myproxy,ssh
+    - IMAGE=centos:centos6 TASK=tests COMPONENTS=gram5
+    - IMAGE=centos:centos7 TASK=tests COMPONENTS=gram5
 #   The following gram tests failed for all fedora versions:
 #       nonblocking-register-test.pl, register-callback-test.pl, register-test.pl
-#    - IMAGE=fedora:25      COMPONENTS=gram5
-#    - IMAGE=fedora:26      COMPONENTS=gram5
-#    - IMAGE=fedora:27      COMPONENTS=gram5
+#    - IMAGE=fedora:25      TASK=tests COMPONENTS=gram5
+#    - IMAGE=fedora:26      TASK=tests COMPONENTS=gram5
+#    - IMAGE=fedora:27      TASK=tests COMPONENTS=gram5
+    - IMAGE=centos:centos7 TASK=tarballs COMPONENTS=ssh,gram5
+
 
 services:
     - docker

--- a/Makefile.am
+++ b/Makefile.am
@@ -99,6 +99,7 @@ osx/$(PACKAGE)-$(VERSION).pkg: $(GT_TARGETS_OSX_PKG) osx/distribution.xml
 		$@
 osx-pkgs: osx/$(PACKAGE)-$(VERSION).pkg
 rpm-pkgs: $(GT_TARGETS_RPM)
+tarballs: $(GT_ALL_TARGETS_DIST)
 
 DOC_STAMPS =
 DOC_PHONY = 

--- a/make-source-tarballs.sh
+++ b/make-source-tarballs.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+# Create source tarballs for all components except gridftp-hdfs in a
+# "package-output/" directory in the repo
+
+# rpm requirements:
+#   make autoconf automake libtool libtool-ltdl-devel patch curl git bison openssl openssl-devel
+
 set -eu
 
 root=$(git rev-parse --show-toplevel)

--- a/make-source-tarballs.sh
+++ b/make-source-tarballs.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -eu
+
+root=$(git rev-parse --show-toplevel)
+cd "$root"
+
+if [[ ! -d packaging ]]; then
+    echo "$root/packaging directory missing -- are you in the right repo?"
+    exit 1
+fi
+
+tmpfile=$(mktemp)
+trap "rm -f $tmpfile" EXIT
+
+
+set -x
+if [[ ! -f Makefile ]]; then
+    if [[ ! -f configure ]]; then
+        echo '================================================================================'
+        time autoreconf -i
+    fi
+    echo '================================================================================'
+    time ./configure --enable-udt --enable-myproxy --enable-gram5-{server,lsf,sge,slurm,condor,pbs,auditing}
+    # ^ not doing --enable-all because that would attempt to enable gridftp-hdfs
+    #   which fails due to missing prerequisites
+fi
+rm -rf package-output
+mkdir package-output
+echo '================================================================================'
+sed -i 's/gridftp_hdfs-dist//' Makefile
+time make tarballs

--- a/travis-ci/make_source_tarballs.sh
+++ b/travis-ci/make_source_tarballs.sh
@@ -3,6 +3,8 @@
 # Create source tarballs for all components except gridftp-hdfs in a
 # "package-output/" directory in the repo
 
+# This can be run manually as well as part of a Travis-CI build
+
 # rpm requirements:
 #   make autoconf automake libtool libtool-ltdl-devel patch curl git bison openssl openssl-devel
 

--- a/travis-ci/setup_tests.sh
+++ b/travis-ci/setup_tests.sh
@@ -2,5 +2,5 @@
 
 # This script starts docker
 
-sudo docker run --rm=true -v `pwd`:/gct:rw ${IMAGE} /bin/bash -c "bash -xe /gct/travis-ci/test_inside_docker.sh ${IMAGE} ${COMPONENTS}"
+sudo docker run --rm=true -v `pwd`:/gct:rw ${IMAGE} /bin/bash -c "bash -xe /gct/travis-ci/test_inside_docker.sh ${IMAGE} ${TASK} ${COMPONENTS}"
 

--- a/travis-ci/test_inside_docker.sh
+++ b/travis-ci/test_inside_docker.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 IMAGE=$1
-COMPONENTS=$2
+TASK=$2
+COMPONENTS=$3
 
 
 set -xe
@@ -25,4 +26,18 @@ yum -y -d1 install "${packages[@]}"
 
 getent passwd builduser > /dev/null || useradd builduser
 chown -R builduser: /gct
-su builduser -c "/bin/bash -xe /gct/travis-ci/test_unpriv_inside_docker.sh $IMAGE $COMPONENTS"
+case $TASK in
+    (tests)
+        su builduser -c "/bin/bash -xe /gct/travis-ci/test_unpriv_inside_docker.sh $IMAGE $COMPONENTS"
+        exit $?
+        ;;
+    (tarballs)
+        cd /gct
+        su builduser -c "/bin/bash -xe /gct/travis-ci/make_source_tarballs.sh"
+        exit $?
+        ;;
+    (*)
+        echo "*** INVALID TASK '$TASK' ***"
+        exit 2
+        ;;
+esac

--- a/travis-ci/test_inside_docker.sh
+++ b/travis-ci/test_inside_docker.sh
@@ -18,7 +18,7 @@ set +e
 [[ $COMPONENTS == *ssh* ]]     && packages+=(curl)
 [[ $COMPONENTS == *udt* ]]     && packages+=(glib2 xz)
 [[ $COMPONENTS == *myproxy* ]] && packages+=(which)
-[[ $COMPONENTS == *gram* ]]    && packages+=('perl(Pod::Html)')
+[[ $COMPONENTS == *gram* ]]    && packages+=('perl(Pod::Html)' bison)
 set -e
 
 yum -y -d1 install "${packages[@]}"


### PR DESCRIPTION
Add a script that builds a full set of source tarballs for the GCT components (except gridftp-hdfs). Can be run standalone easily, but added config to run via Travis: https://travis-ci.org/matyasselmeci/gct/builds/308697470