### PR TITLE
Also create gct source installer tarball

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,19 +1,9 @@
-m4_define([globus_buildno], [m4_syscmd([
-if test -e .git ; then
-    git log -n 1 --pretty=format:%ct > globus-version.inc.new;
-    if ! cmp globus-version.inc.new globus-version.inc > /dev/null 2>&1; then
-        mv globus-version.inc.new globus-version.inc
-    else
-        rm globus-version.inc.new
-    fi
-fi])dnl
-m4_[]include(globus-version.inc)])dnl
-m4_define([gtreleasebuild], [6.0.]globus_buildno)
-AC_INIT([globus_toolkit], gtreleasebuild, [https://github.com/globus/globus-toolkit/issues])
+m4_define([gtreleasebuild], [6.9.0])
+AC_INIT([gct], gtreleasebuild, [https://github.com/gridcf/gct/issues])
 
 m4_define([short_version], [m4_substr(AC_PACKAGE_VERSION, [0],
     m4_index(AC_PACKAGE_VERSION, [.]))])
-AC_PREFIX_DEFAULT([/usr/local/globus-]short_version)
+AC_PREFIX_DEFAULT([/usr/local/gct-]short_version)
 export GLOBUS_VERSION=$VERSION
 syscmd([./update-dirt.sh])
 syscmd([test -x ./prep-gsissh && sh -x ./prep-gsissh || true])

--- a/travis-ci/make_source_tarballs.sh
+++ b/travis-ci/make_source_tarballs.sh
@@ -36,7 +36,12 @@ rm -rf package-output
 mkdir package-output
 echo '================================================================================'
 sed -i 's/gridftp_hdfs-dist//' Makefile
-make dist && mv gct-*.tar.gz package-output/
+
+# Also create source installer tarball
+package_name=$(grep '^PACKAGE_NAME =' Makefile | cut -d ' ' -f 3)
+package_version=$(grep '^PACKAGE_VERSION =' Makefile | cut -d ' ' -f 3)
+make dist && mv "${package_name}-${package_version}.tar.gz" package-output/
+
 time make -j1 tarballs
 
 echo '================================================================================'

--- a/travis-ci/make_source_tarballs.sh
+++ b/travis-ci/make_source_tarballs.sh
@@ -10,7 +10,6 @@
 
 set -eu
 
-source_installer_tarball="gct-source.tar.gz"
 root=$(git rev-parse --show-toplevel)
 cd "$root"
 
@@ -27,14 +26,6 @@ if [[ ! -f Makefile ]]; then
     if [[ ! -f configure ]]; then
         echo '================================================================================'
         time autoreconf -i
-        if [[ $? -eq 0 ]]; then
-            cd "$root/.."
-            tar -czf $source_installer_tarball --exclude='.git/' "$root"
-            cd "$root"
-        else
-            echo "autoreconf failed. Cannot continue. Exiting" 1>&2
-            exit 1
-        fi
     fi
     echo '================================================================================'
     time ./configure --enable-udt --enable-myproxy --enable-gram5-{server,lsf,sge,slurm,condor,pbs,auditing}
@@ -43,9 +34,9 @@ if [[ ! -f Makefile ]]; then
 fi
 rm -rf package-output
 mkdir package-output
-mv "$root/../$source_installer_tarball" "$root/package-output/"
 echo '================================================================================'
 sed -i 's/gridftp_hdfs-dist//' Makefile
+make dist
 time make -j1 tarballs
 
 echo '================================================================================'

--- a/travis-ci/make_source_tarballs.sh
+++ b/travis-ci/make_source_tarballs.sh
@@ -10,6 +10,7 @@
 
 set -eu
 
+source_installer_tarball="gct-source.tar.gz"
 root=$(git rev-parse --show-toplevel)
 cd "$root"
 
@@ -26,6 +27,14 @@ if [[ ! -f Makefile ]]; then
     if [[ ! -f configure ]]; then
         echo '================================================================================'
         time autoreconf -i
+        if [[ $? -eq 0 ]]; then
+            cd "$root/.."
+            tar -czf $source_installer_tarball --exclude='.git/' "$root"
+            cd "$root"
+        else
+            echo "autoreconf failed. Cannot continue. Exiting" 1>&2
+            exit 1
+        fi
     fi
     echo '================================================================================'
     time ./configure --enable-udt --enable-myproxy --enable-gram5-{server,lsf,sge,slurm,condor,pbs,auditing}
@@ -34,6 +43,7 @@ if [[ ! -f Makefile ]]; then
 fi
 rm -rf package-output
 mkdir package-output
+mv "$root/../$source_installer_tarball" "$root/package-output/"
 echo '================================================================================'
 sed -i 's/gridftp_hdfs-dist//' Makefile
 time make -j1 tarballs

--- a/travis-ci/make_source_tarballs.sh
+++ b/travis-ci/make_source_tarballs.sh
@@ -36,7 +36,7 @@ rm -rf package-output
 mkdir package-output
 echo '================================================================================'
 sed -i 's/gridftp_hdfs-dist//' Makefile
-make dist
+make dist && mv gct-*.tar.gz package-output/
 time make -j1 tarballs
 
 echo '================================================================================'

--- a/write-globus-version
+++ b/write-globus-version
@@ -2,5 +2,5 @@
 
 cat <<EOF > common/source/globus_version
 GLOBUS_VERSION="\${GLOBUS_VERSION:-$1}"
-GLOBUS_VERSIONNAME="\${GLOBUS_VERSIONNAME:-Globus Toolkit}"
+GLOBUS_VERSIONNAME="\${GLOBUS_VERSIONNAME:-Grid Community Toolkit}"
 EOF


### PR DESCRIPTION
This contains all gct source files (w/gsi-openssh patches but w/o .git and
below) with "autoreconf -i" already ran. This is similar to what Globus
shipped as "Source Tarball" from e.g. [1].

[1]: http://toolkit.globus.org/toolkit/downloads/latest-stable/

