### PR TITLE
Add more unames

### DIFF
--- a/gridftp/server/src/globus-gridftp-server-setup-chroot
+++ b/gridftp/server/src/globus-gridftp-server-setup-chroot
@@ -54,7 +54,7 @@ mkdir -p -m 755 "$ROOT_DIR/dev"
 devs="zero null random urandom"
 
 case $(uname) in
-    Linux|Darwin|SunOS)
+    Linux|Darwin|SunOS|GNU|GNU/kFreeBSD)
         (cd /dev; tar chf - $devs) | (cd "$ROOT_DIR/dev"; tar xf -)
         ;;
 esac


### PR DESCRIPTION
This is a rebase of an unmerged pull request in the globus-toolkit repo:
https://github.com/globus/globus-toolkit/pull/32
It is applied in the Fedora/EPEL/Debian package builds.
Original description:

Fixes broken tests on hurd and freebsd.
