### PR TITLE
Move grid-proxy-destroy call to before starting personal gatekeeper

### DIFF
--- a/gram/jobmanager/source/test/gram-test-wrapper.in
+++ b/gram/jobmanager/source/test/gram-test-wrapper.in
@@ -48,6 +48,8 @@ if [ -n "$PERL5LIB" ]; then
     export PERL5LIB
 fi
 
+grid-proxy-destroy 2>/dev/null || true
+
 if [ -n "$CONTACT_STRING" ]; then
     echo "#   Using existing GRAM service at $CONTACT_STRING"
 else
@@ -75,8 +77,6 @@ else
     trap cleanup EXIT
     export CONTACT_STRING="$contact"
 fi
-
-grid-proxy-destroy 2>/dev/null || true 
 
 # Perl scripts pass through, otherwise run the program under valgrind
 # conditionally


### PR DESCRIPTION
This is a rebase of an unmerged pull request in the globus-toolkit repo:
https://github.com/globus/globus-toolkit/pull/42
It is applied in the Fedora/EPEL/Debian package builds.
Original description:

If there is a proxy file around the first test fails. By moving the call to grid-proxy-destroy to before starting the personal gatekeeper, this is fixed.

(Only the first test fails because when the second test is run the grid-proxy-destroy from the first test has removed the proxy.)
