### PR TITLE
Get command string

### DIFF
--- a/gridftp/server-lib/src/globus_gridftp_server_control.h
+++ b/gridftp/server-lib/src/globus_gridftp_server_control.h
@@ -697,6 +697,10 @@ globus_bool_t
 globus_gridftp_server_control_authenticated(
     globus_gridftp_server_control_t         server);
 
+char *
+globus_gridftp_server_control_get_cmd_string(
+    globus_gridftp_server_control_op_t      op);
+
 /***************************************************************************
  *  data object
  *

--- a/gridftp/server-lib/src/globus_gridftp_server_control_accessors.c
+++ b/gridftp/server-lib/src/globus_gridftp_server_control_accessors.c
@@ -21,6 +21,27 @@
  *                      get functions
  *                      -------------
  ************************************************************************/
+char *
+globus_gridftp_server_control_get_cmd_string(
+    globus_gridftp_server_control_op_t      op)
+{
+    char *                                  cmd = NULL;
+    GlobusGridFTPServerName(globus_gridftp_server_control_get_cmd_string);
+
+    if(op == NULL)
+    {
+        return NULL;
+    }
+
+    globus_mutex_lock(&op->server_handle->mutex);
+    {
+        cmd = globus_libc_strdup(op->command);
+    }
+    globus_mutex_unlock(&op->server_handle->mutex);
+
+    return cmd;
+}
+
 globus_bool_t
 globus_gridftp_server_control_authenticated(
     globus_gridftp_server_control_t         server)

--- a/gridftp/server/src/globus_gridftp_server.h
+++ b/gridftp/server/src/globus_gridftp_server.h
@@ -1279,6 +1279,10 @@ globus_gfs_data_get_file_stack_list(
     globus_gfs_operation_t              in_op,
     globus_list_t **                    out_list);
 
+char *
+globus_gfs_data_get_cmd_string(
+    globus_gfs_operation_t              op);
+
 void
 globus_gridftp_server_get_update_interval(
     globus_gfs_operation_t              op,

--- a/gridftp/server/src/globus_i_gfs_control.c
+++ b/gridftp/server/src/globus_i_gfs_control.c
@@ -953,6 +953,20 @@ error_init:
     GlobusGFSDebugExitWithError();
 }
 
+char *
+globus_i_gsc_get_cmd_string(
+    void *                              user_arg)
+{
+    globus_l_gfs_request_info_t *       request;
+    char *                              cmd = NULL;
+    GlobusGFSName(globus_i_gsc_get_cmd_string);
+
+    request = (globus_l_gfs_request_info_t *) user_arg;
+    cmd = globus_gridftp_server_control_get_cmd_string(request->control_op);
+
+    return cmd;
+}
+
 globus_result_t
 globus_i_gsc_cmd_intermediate_reply(
     globus_gridftp_server_control_op_t  op,

--- a/gridftp/server/src/globus_i_gfs_control.h
+++ b/gridftp/server/src/globus_i_gfs_control.h
@@ -28,4 +28,8 @@ globus_i_gfs_control_start(
     globus_i_gfs_server_close_cb_t      close_func,
     void *                              user_arg);
 
+char *
+globus_i_gsc_get_cmd_string(
+    void *                              user_arg);
+
 #endif

--- a/gridftp/server/src/globus_i_gfs_data.c
+++ b/gridftp/server/src/globus_i_gfs_data.c
@@ -6841,6 +6841,16 @@ globus_gfs_data_get_file_stack_list(
     }
 }
 
+char *
+globus_gfs_data_get_cmd_string(
+    globus_gfs_operation_t              op)
+{
+    char *                              cmd = NULL;
+
+    cmd = globus_i_gsc_get_cmd_string(op->user_arg);
+
+    return cmd;
+}
 
 static
 globus_result_t


### PR DESCRIPTION
This is a rebase of an unmerged pull request in the globus-toolkit repo:
https://github.com/globus/globus-toolkit/pull/98
It is applied in the Fedora/EPEL/Debian package builds.
Original description:

This pull request is forwarded from the developers of DPM (disk pool manager). Their description of the proposed change follows. The pull request is created using the patches mentioned below. The original author of the text below is @andrea-manzi.

"Similarly given that we didn't get any answer from the ticket we opened to globus,

We would like to understand if it's possible to patch the same packages in order for us to stop including the gridftp internal structures in our dpm-dsi builds and thus freeing the strict dep between
globus-gridftp-server and dpm-dsi.

Andrey prepared 2 patches also for this, one for globus-gridftp-server:

https://cern.ch/kiryanov/gridftp_server_cmd_string.patch

and one for globus-gridftp-server-control:

https://cern.ch/kiryanov/gridftp_server_control_cmd_string.patch

let us know what do you think about this."
