### PR TITLE
Gridftpd configd files

### DIFF
--- a/gridftp/server/src/globus-gridftp-server.8
+++ b/gridftp/server/src/globus-gridftp-server.8
@@ -961,9 +961,8 @@ Path to main configuration file that should be loaded\&. Otherwise will attempt 
 .PP
 \fB\-C string\fR
 .RS 4
-Path to directory holding configuration files that should be loaded\&. Files will be loaded in alphabetical order, and in the event of duplicate parameters the last loaded file will take precedence\&. Files with a
-\fI\&.\fR
-in the name (file\&.bak, file\&.rpmsave, etc\&.) will be ignored\&. Note that the main configuration file, if one exists, will always be loaded last\&.
+Path to directory holding configuration files that should be loaded\&. Files will be loaded in alphabetical order, and in the event of duplicate parameters the last loaded file will take precedence\&. Backup files and files created by package updates (e.g. file\&.rpmsave) will be ignored\&.
+Note that the main configuration file, if one exists, will always be loaded last\&.
 .sp
 This option can also be set in the configuration file as
 config_dir\&.

--- a/gridftp/server/src/globus_i_gfs_config.c
+++ b/gridftp/server/src/globus_i_gfs_config.c
@@ -493,8 +493,8 @@ static const globus_l_gfs_config_option_t option_list[] =
  {"config_dir", "config_dir", NULL, "C", NULL, GLOBUS_L_GFS_CONFIG_STRING, 0, NULL,
      "Path to directory holding configuration files that should be loaded. Files "
      "will be loaded in alphabetical order, and in the event of duplicate parameters "
-     "the last loaded file will take precedence.  Files with a '.' in the name "
-     "(file.bak, file.rpmsave, etc.) will be ignored.  Note that the main "
+     "the last loaded file will take precedence.  Backup files and files created by "
+     "package updates (e.g. file.rpmsave) will be ignored.  Note that the main "
      "configuration file, if one exists, will always be loaded last.", NULL, NULL,GLOBUS_FALSE, NULL},
  {"config_base_path", "config_base_path", NULL, "config-base-path", NULL, GLOBUS_L_GFS_CONFIG_STRING, 0, NULL,
      "Base path to use when config and log path options are not full paths. "
@@ -1160,9 +1160,10 @@ globus_l_gfs_config_load_config_dir(
         {
             char *                      full_path;
             
-            /* skip any file with a '.': hidden, . or ..
-             and files like .rpm*, .deb*, .bak*, etc */
-            if(strchr(entries[i]->d_name, '.') != NULL)
+            /* skip hidden and . or ..
+             and files possibly created by updates .rpmsave or .rpmnew */
+            if(*entries[i]->d_name == '.' ||
+                strstr(entries[i]->d_name, '.rpm') != NULL)
             {
                 free(entries[i]);
                 continue;


### PR DESCRIPTION
This is a rebase of an unmerged pull request in the globus-toolkit repo:
https://github.com/globus/globus-toolkit/pull/118
It is applied in the Fedora/EPEL/Debian package builds.
Original description:

Instead of ignoring all files with a . in the name in /etc/config.d, only ignore backup files (.bak, ~) and packaging files (.rpmsave, etc.).
