### PR TITLE
Install libffi-devel if we're building UDT

### DIFF
--- a/travis-ci/run_task_inside_docker.sh
+++ b/travis-ci/run_task_inside_docker.sh
@@ -26,7 +26,7 @@ packages=(gcc gcc-c++ make autoconf automake libtool \
 
 if [[ $TASK == tests ]]; then
     set +e
-    [[ $COMPONENTS == *udt* ]]     && packages+=(glib2 xz)
+    [[ $COMPONENTS == *udt* ]]     && packages+=(glib2 xz libffi-devel)
     [[ $COMPONENTS == *myproxy* ]] && packages+=(which)
     [[ $COMPONENTS == *gram* ]]    && packages+=('perl(Pod::Html)')
     set -e


### PR DESCRIPTION
This should fix the build failures from the libffi tarball.