### PR TITLE
Add BuildRequires: gcc

### DIFF
--- a/packaging/fedora/globus-authz-callout-error.spec
+++ b/packaging/fedora/globus-authz-callout-error.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	doxygen
 

--- a/packaging/fedora/globus-authz.spec
+++ b/packaging/fedora/globus-authz.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-callout-devel >= 2
 BuildRequires:	globus-gssapi-gsi-devel >= 9

--- a/packaging/fedora/globus-callout.spec
+++ b/packaging/fedora/globus-callout.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 15
 %if %{?suse_version}%{!?suse_version:0}
 BuildRequires:	libtool

--- a/packaging/fedora/globus-common.spec
+++ b/packaging/fedora/globus-common.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 %if %{?suse_version}%{!?suse_version:0}
 BuildRequires:	libtool
 %else

--- a/packaging/fedora/globus-ftp-client.spec
+++ b/packaging/fedora/globus-ftp-client.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 15
 BuildRequires:	globus-ftp-control-devel >= 4
 BuildRequires:	globus-gsi-callback-devel >= 4

--- a/packaging/fedora/globus-ftp-control.spec
+++ b/packaging/fedora/globus-ftp-control.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gss-assist-devel >= 11
 BuildRequires:	globus-gssapi-gsi-devel >= 13

--- a/packaging/fedora/globus-gass-cache-program.spec
+++ b/packaging/fedora/globus-gass-cache-program.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gass-cache-devel >= 8
 BuildRequires:	globus-gass-copy-devel >= 8

--- a/packaging/fedora/globus-gass-cache.spec
+++ b/packaging/fedora/globus-gass-cache.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 %if %{?suse_version}%{!?suse_version:0}
 BuildRequires:	libopenssl-devel

--- a/packaging/fedora/globus-gass-copy.spec
+++ b/packaging/fedora/globus-gass-copy.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 15
 BuildRequires:	globus-ftp-client-devel >= 7
 BuildRequires:	globus-ftp-control-devel >= 4

--- a/packaging/fedora/globus-gass-server-ez.spec
+++ b/packaging/fedora/globus-gass-server-ez.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gass-transfer-devel >= 7
 BuildRequires:	globus-gssapi-gsi-devel >= 10

--- a/packaging/fedora/globus-gass-transfer.spec
+++ b/packaging/fedora/globus-gass-transfer.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gssapi-gsi-devel >= 10
 BuildRequires:	globus-gss-assist-devel >= 8

--- a/packaging/fedora/globus-gatekeeper.spec
+++ b/packaging/fedora/globus-gatekeeper.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gss-assist-devel >= 8
 BuildRequires:	globus-gssapi-gsi-devel >= 9

--- a/packaging/fedora/globus-gfork.spec
+++ b/packaging/fedora/globus-gfork.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-xio-devel >= 3
 

--- a/packaging/fedora/globus-gram-client-tools.spec
+++ b/packaging/fedora/globus-gram-client-tools.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gram-client-devel >= 12
 BuildRequires:	globus-gram-protocol-devel >= 11

--- a/packaging/fedora/globus-gram-client.spec
+++ b/packaging/fedora/globus-gram-client.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gram-protocol-devel >= 11
 BuildRequires:	globus-io-devel >= 9

--- a/packaging/fedora/globus-gram-job-manager-callout-error.spec
+++ b/packaging/fedora/globus-gram-job-manager-callout-error.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	doxygen
 

--- a/packaging/fedora/globus-gram-job-manager-fork.spec
+++ b/packaging/fedora/globus-gram-job-manager-fork.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-xio-devel >= 3
 BuildRequires:	globus-scheduler-event-generator-devel >= 4

--- a/packaging/fedora/globus-gram-job-manager-lsf.spec
+++ b/packaging/fedora/globus-gram-job-manager-lsf.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-scheduler-event-generator-devel >= 4
 %if ! %{?suse_version}%{!?suse_version:0}

--- a/packaging/fedora/globus-gram-job-manager-pbs.spec
+++ b/packaging/fedora/globus-gram-job-manager-pbs.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-scheduler-event-generator-devel >= 4
 %if ! %{?suse_version}%{!?suse_version:0}

--- a/packaging/fedora/globus-gram-job-manager-sge.spec
+++ b/packaging/fedora/globus-gram-job-manager-sge.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-scheduler-event-generator-devel >= 4
 %if ! %{?suse_version}%{!?suse_version:0}

--- a/packaging/fedora/globus-gram-job-manager.spec
+++ b/packaging/fedora/globus-gram-job-manager.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 15
 BuildRequires:	globus-gsi-credential-devel >= 5
 BuildRequires:	globus-gass-cache-devel >= 8

--- a/packaging/fedora/globus-gram-protocol.spec
+++ b/packaging/fedora/globus-gram-protocol.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-io-devel >= 8
 BuildRequires:	globus-gssapi-gsi-devel >= 10

--- a/packaging/fedora/globus-gridftp-server-control.spec
+++ b/packaging/fedora/globus-gridftp-server-control.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-xio-devel >= 3
 BuildRequires:	globus-xio-gsi-driver-devel >= 2

--- a/packaging/fedora/globus-gridftp-server.spec
+++ b/packaging/fedora/globus-gridftp-server.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 17
 BuildRequires:	globus-xio-devel >= 5
 BuildRequires:	globus-xio-gsi-driver-devel >= 2

--- a/packaging/fedora/globus-gridmap-callout-error.spec
+++ b/packaging/fedora/globus-gridmap-callout-error.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gssapi-error-devel >= 4
 BuildRequires:	doxygen

--- a/packaging/fedora/globus-gridmap-callout.spec
+++ b/packaging/fedora/globus-gridmap-callout.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gssapi-gsi-devel >= 4
 BuildRequires:	globus-gss-assist-devel >= 3

--- a/packaging/fedora/globus-gridmap-eppn-callout.spec
+++ b/packaging/fedora/globus-gridmap-eppn-callout.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gsi-sysconfig-devel >= 5
 BuildRequires:	globus-gssapi-gsi-devel >= 9

--- a/packaging/fedora/globus-gridmap-verify-myproxy-callout.spec
+++ b/packaging/fedora/globus-gridmap-verify-myproxy-callout.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gsi-sysconfig-devel >= 5
 BuildRequires:	globus-gssapi-gsi-devel >= 9

--- a/packaging/fedora/globus-gsi-callback.spec
+++ b/packaging/fedora/globus-gsi-callback.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-openssl-module-devel >= 3
 BuildRequires:	globus-gsi-openssl-error-devel >= 2
 BuildRequires:	globus-gsi-cert-utils-devel >= 8

--- a/packaging/fedora/globus-gsi-cert-utils.spec
+++ b/packaging/fedora/globus-gsi-cert-utils.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-openssl-module-devel >= 3
 BuildRequires:	globus-gsi-openssl-error-devel >= 2

--- a/packaging/fedora/globus-gsi-credential.spec
+++ b/packaging/fedora/globus-gsi-credential.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gsi-openssl-error-devel >= 2
 BuildRequires:	globus-gsi-cert-utils-devel >= 8

--- a/packaging/fedora/globus-gsi-openssl-error.spec
+++ b/packaging/fedora/globus-gsi-openssl-error.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 %if %{?suse_version}%{!?suse_version:0}
 BuildRequires:	libopenssl-devel

--- a/packaging/fedora/globus-gsi-proxy-core.spec
+++ b/packaging/fedora/globus-gsi-proxy-core.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-openssl-module-devel >= 3
 BuildRequires:	globus-gsi-openssl-error-devel >= 2
 BuildRequires:	globus-gsi-cert-utils-devel >= 8

--- a/packaging/fedora/globus-gsi-proxy-ssl.spec
+++ b/packaging/fedora/globus-gsi-proxy-ssl.spec
@@ -14,6 +14,7 @@ Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %if %{?suse_version}%{!?suse_version:0}
+BuildRequires:	gcc
 BuildRequires:	libopenssl-devel
 %else
 BuildRequires:	openssl-devel

--- a/packaging/fedora/globus-gsi-sysconfig.spec
+++ b/packaging/fedora/globus-gsi-sysconfig.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 15
 BuildRequires:	globus-openssl-module-devel >= 3
 BuildRequires:	globus-gsi-openssl-error-devel >= 2

--- a/packaging/fedora/globus-gss-assist.spec
+++ b/packaging/fedora/globus-gss-assist.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gsi-sysconfig-devel >= 7
 BuildRequires:	globus-gsi-cert-utils-devel >= 8

--- a/packaging/fedora/globus-gssapi-error.spec
+++ b/packaging/fedora/globus-gssapi-error.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gss-assist-devel >= 8
 BuildRequires:	globus-gssapi-gsi-devel >= 9

--- a/packaging/fedora/globus-gssapi-gsi.spec
+++ b/packaging/fedora/globus-gssapi-gsi.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-openssl-module-devel >= 3
 BuildRequires:	globus-gsi-openssl-error-devel >= 2

--- a/packaging/fedora/globus-io.spec
+++ b/packaging/fedora/globus-io.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-xio-devel >= 3
 BuildRequires:	globus-gss-assist-devel >= 8

--- a/packaging/fedora/globus-net-manager.spec
+++ b/packaging/fedora/globus-net-manager.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 15.27
 BuildRequires:	globus-xio-devel >= 5
 BuildRequires:	doxygen

--- a/packaging/fedora/globus-openssl-module.spec
+++ b/packaging/fedora/globus-openssl-module.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-gsi-proxy-ssl-devel >= 4
 BuildRequires:	globus-gsi-openssl-error-devel >= 2

--- a/packaging/fedora/globus-proxy-utils.spec
+++ b/packaging/fedora/globus-proxy-utils.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-openssl-module-devel >= 3
 BuildRequires:	globus-gsi-openssl-error-devel >= 2

--- a/packaging/fedora/globus-rsl.spec
+++ b/packaging/fedora/globus-rsl.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	doxygen
 

--- a/packaging/fedora/globus-scheduler-event-generator.spec
+++ b/packaging/fedora/globus-scheduler-event-generator.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-xio-devel >= 3
 BuildRequires:	globus-gram-protocol-devel >= 11

--- a/packaging/fedora/globus-usage.spec
+++ b/packaging/fedora/globus-usage.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-xio-devel >= 3
 

--- a/packaging/fedora/globus-xio-gridftp-driver.spec
+++ b/packaging/fedora/globus-xio-gridftp-driver.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-xio-devel >= 3
 BuildRequires:	globus-ftp-client-devel >= 7

--- a/packaging/fedora/globus-xio-gridftp-multicast.spec
+++ b/packaging/fedora/globus-xio-gridftp-multicast.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-xio-devel >= 3
 BuildRequires:	globus-ftp-client-devel >= 7

--- a/packaging/fedora/globus-xio-gsi-driver.spec
+++ b/packaging/fedora/globus-xio-gsi-driver.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-xio-devel >= 3
 BuildRequires:	globus-gss-assist-devel >= 11
 BuildRequires:	globus-gssapi-error-devel >= 4

--- a/packaging/fedora/globus-xio-pipe-driver.spec
+++ b/packaging/fedora/globus-xio-pipe-driver.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-xio-devel >= 3
 BuildRequires:	globus-common-devel >= 14
 

--- a/packaging/fedora/globus-xio-popen-driver.spec
+++ b/packaging/fedora/globus-xio-popen-driver.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-xio-devel >= 3
 

--- a/packaging/fedora/globus-xio-rate-driver.spec
+++ b/packaging/fedora/globus-xio-rate-driver.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-xio-devel >= 3
 

--- a/packaging/fedora/globus-xio-udt-driver.spec
+++ b/packaging/fedora/globus-xio-udt-driver.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	gcc-c++
 BuildRequires:	globus-xio-devel >= 3
 BuildRequires:	globus-common-devel >= 14

--- a/packaging/fedora/globus-xio.spec
+++ b/packaging/fedora/globus-xio.spec
@@ -13,6 +13,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	doxygen
 #		Additional requirements for make check

--- a/packaging/fedora/globus-xioperf.spec
+++ b/packaging/fedora/globus-xioperf.spec
@@ -12,6 +12,7 @@ URL:		https://github.com/gridcf/gct/
 Source:		%{_name}-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:	gcc
 BuildRequires:	globus-common-devel >= 14
 BuildRequires:	globus-xio-devel >= 3
 

--- a/packaging/fedora/gridftp-hdfs.spec
+++ b/packaging/fedora/gridftp-hdfs.spec
@@ -10,6 +10,7 @@ URL:            http://twiki.grid.iu.edu/bin/view/Storage/HadoopInstallation
 Source:         %{_name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires: gcc
 %if 0%{?suse_version} > 0
 BuildRequires: java-sdk >= 1.7.0
 %else

--- a/packaging/fedora/myproxy.spec
+++ b/packaging/fedora/myproxy.spec
@@ -12,6 +12,7 @@ URL:            http://grid.ncsa.illinois.edu/myproxy/
 Source:         %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+BuildRequires:  gcc
 BuildRequires:  globus-common-devel >= 14
 BuildRequires:  globus-usage-devel >= 3
 BuildRequires:  globus-gssapi-gsi-devel >= 9


### PR DESCRIPTION
This is to adapt to an upcoming change scheduled for Fedora 29:
https://fedoraproject.org/wiki/Changes/Remove_GCC_from_BuildRoot
