### PR TITLE
Add symlink to .travis.yml for convenience

### DIFF
--- a/travis-ci/travis.yml
+++ b/travis-ci/travis.yml
@@ -1,0 +1,1 @@
+../.travis.yml


### PR DESCRIPTION
Useful for it to be in the same dir as all our other travis stuff and also not be hidden.