### PR TITLE
Avoid TLS 1.3 for now

### DIFF
--- a/gsi/gssapi/source/configure.ac
+++ b/gsi/gssapi/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gssapi_gsi],[14.1],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gssapi_gsi],[14.2],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gsi/gssapi/source/library/globus_i_gsi_gss_utils.c
+++ b/gsi/gssapi/source/library/globus_i_gsi_gss_utils.c
@@ -2301,7 +2301,10 @@ globus_i_gsi_gssapi_init_ssl_context(
     if (globus_i_gsi_gssapi_min_tls_protocol == 0)
         globus_i_gsi_gssapi_min_tls_protocol = TLS1_VERSION;
     if (globus_i_gsi_gssapi_max_tls_protocol == 0)
-        globus_i_gsi_gssapi_max_tls_protocol = TLS_MAX_VERSION;
+        // The GSI GSSAPI currently does not work with TLS 1.3
+        // Use TLS1_2_VERSION instead of TLS_MAX_VERSION as the maximum TLS
+        // protocol version until it has been ported
+        globus_i_gsi_gssapi_max_tls_protocol = TLS1_2_VERSION;
     GLOBUS_I_GSI_GSSAPI_DEBUG_FPRINTF(
         3, (globus_i_gsi_gssapi_debug_fstream,
         "MIN_TLS_PROTOCOL: %x\n", globus_i_gsi_gssapi_min_tls_protocol));

--- a/packaging/debian/globus-gssapi-gsi/debian/changelog.in
+++ b/packaging/debian/globus-gssapi-gsi/debian/changelog.in
@@ -1,3 +1,12 @@
+globus-gssapi-gsi (14.2-1+gct.@distro@) @distro@; urgency=medium
+
+  * Avoid TLS 1.3 for now
+    The GSI GSSAPI currently does not work with TLS 1.3
+    Use TLS1_2_VERSION instead of TLS_MAX_VERSION as the maximum TLS
+    protocol version until it has been ported
+
+ -- Mattias Ellert <mattias.ellert@physica.uu.se>  Fri, 25 May 2018 14:01:08 +0200
+
 globus-gssapi-gsi (14.1-1+gct.@distro@) @distro@; urgency=medium
 
   * Use 2048 bit RSA key for tests

--- a/packaging/fedora/globus-gssapi-gsi.spec
+++ b/packaging/fedora/globus-gssapi-gsi.spec
@@ -3,7 +3,7 @@
 Name:		globus-gssapi-gsi
 %global soname 4
 %global _name %(tr - _ <<< %{name})
-Version:	14.1
+Version:	14.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GSSAPI library
 
@@ -154,6 +154,12 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Fri May 25 2018 Mattias Ellert <mattias.ellert@physics.uu.se> - 14.2-1
+- Avoid TLS 1.3 for now
+  The GSI GSSAPI currently does not work with TLS 1.3
+  Use TLS1_2_VERSION instead of TLS_MAX_VERSION as the maximum TLS
+  protocol version until it has been ported
+
 * Sat May 05 2018 Mattias Ellert <mattias.ellert@physics.uu.se> - 14.1-1
 - Use 2048 bit RSA key for tests
 


### PR DESCRIPTION
The GSI GSSAPI currently does not work with TLS 1.3. Use TLS1_2_VERSION instead of TLS_MAX_VERSION as the maximum TLS protocol version until it has been ported.

This is a workaround for #43 but not a fix. The proper fix would be to make the code work with TLS 1.3 rather than avoiding the issue by limiting the TLS version to <= 1.2. Hopefully that will eventually happen.
