### PR TITLE
Also create gct source installer tarball v2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ if test -e .git ; then
 fi])dnl
 m4_[]include(globus-version.inc)])dnl
 m4_define([gtreleasebuild], [6.0.]globus_buildno)
-AC_INIT([globus_toolkit], gtreleasebuild, [https://github.com/gridcf/gct/issues])
+AC_INIT([gct], gtreleasebuild, [https://github.com/gridcf/gct/issues])
 
 m4_define([short_version], [m4_substr(AC_PACKAGE_VERSION, [0],
     m4_index(AC_PACKAGE_VERSION, [.]))])

--- a/travis-ci/make_source_tarballs.sh
+++ b/travis-ci/make_source_tarballs.sh
@@ -39,6 +39,12 @@ sed -i 's/gridftp_hdfs-dist//' Makefile
 time make -j1 tarballs
 
 echo '================================================================================'
+# Also create source installer tarball
+package_name=$(grep '^PACKAGE_NAME =' Makefile | cut -d ' ' -f 3)
+package_version=$(grep '^PACKAGE_VERSION =' Makefile | cut -d ' ' -f 3)
+time make dist && mv "${package_name}-${package_version}.tar.gz" package-output/
+
+echo '================================================================================'
 pushd "$root/myproxy/oauth/source"
 time python setup.py sdist
 mv dist/*.tar.gz "$root/package-output/"


### PR DESCRIPTION
[v1] -> v2:

  - version number is kept as is
  - default prefix is kept as is

[v1]: https://github.com/gridcf/gct/pull/11