### PR TITLE
Split guc-cc.pl test into smaller tests

### DIFF
--- a/gass/copy/source/configure.ac
+++ b/gass/copy/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gass_copy],[10.2],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gass_copy],[10.3],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gass/copy/source/test/Makefile.am
+++ b/gass/copy/source/test/Makefile.am
@@ -2,27 +2,39 @@ EXTRA_SCRIPTS = test-wrapper
 
 check_SCRIPTS_skip =
 check_SCRIPTS_run = \
-        guc-fw.pl \
-        guc-pp-cc.pl \
-        guc-stack.pl
+	guc-fw.pl \
+	guc-pp-cc.pl \
+	guc-stack.pl
 if MINGW32
-check_SCRIPTS_skip += guc-cc.pl
+check_SCRIPTS_skip += \
+	guc-cc.pl \
+	guc-cc-fast.pl \
+	guc-cc-p2.pl \
+	guc-cc-p4.pl \
+	guc-cc-stripe.pl \
+	guc-cc-stripe-p4.pl
 else
-check_SCRIPTS_run += guc-cc.pl
+check_SCRIPTS_run += \
+	guc-cc.pl \
+	guc-cc-fast.pl \
+	guc-cc-p2.pl \
+	guc-cc-p4.pl \
+	guc-cc-stripe.pl \
+	guc-cc-stripe-p4.pl
 endif
 
 check_SCRIPTS = $(check_SCRIPTS_skip) $(check_SCRIPTS_run)
 
 if ENABLE_TESTS
 check_DATA =  \
-        testcred.key \
-        testcred.cert \
-        testcred.cakey \
-        testcred.cacert \
-        testcred.link \
-        testcred.signing_policy \
-        testcred.srl \
-        testcred.gridmap
+	testcred.key \
+	testcred.cert \
+	testcred.cakey \
+	testcred.cacert \
+	testcred.link \
+	testcred.signing_policy \
+	testcred.srl \
+	testcred.gridmap
 
 # Test CA
 .cnf.cacert:
@@ -34,7 +46,7 @@ check_DATA =  \
 	linkname="`$(OPENSSL) x509 -hash -noout -in $<`.0"; \
 	rm -f "$$linkname"; \
 	cp $< "$$linkname"; \
-        echo "$$linkname" > $@
+	echo "$$linkname" > $@
 
 .link.signing_policy:
 	linkname=`cat $<`; \
@@ -58,7 +70,7 @@ check_DATA =  \
 
 .cert.gridmap:
 	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt rfc2253,-dn_rev | sed -e 's/subject= */\//' -e 's/,/\//g'` ; \
-        echo "\"$$subject\" `id -un`" > $@
+	echo "\"$$subject\" `id -un`" > $@
 
 if CYGPATH_W_DEFINED
 X509_CERT_DIR = $$($(CYGPATH_W) $(abs_builddir))
@@ -92,8 +104,8 @@ CLEANFILES = testcred.key testcred.cert testcred.req \
 	     testcred.cakey testcred.gridmap
 clean-local:
 	if [ -f testcred.link ]; then \
-            rm -f "$$(cat testcred.link)" testcred.link; \
-        fi
+	    rm -f "$$(cat testcred.link)" testcred.link; \
+	fi
 	if test -f testcred.signing_policy; then \
 	    rm -f $$(cat testcred.signing_policy) testcred.signing_policy; \
 	fi

--- a/gass/copy/source/test/guc-cc-fast.pl
+++ b/gass/copy/source/test/guc-cc-fast.pl
@@ -1,0 +1,3 @@
+#!/usr/bin/perl
+system('./guc-cc.pl -fast');
+exit($? >> 8);

--- a/gass/copy/source/test/guc-cc-fast.pl
+++ b/gass/copy/source/test/guc-cc-fast.pl
@@ -1,3 +1,4 @@
 #!/usr/bin/perl
-system('./guc-cc.pl -fast');
+use File::Basename;
+system(dirname($0) . '/guc-cc.pl -fast');
 exit($? >> 8);

--- a/gass/copy/source/test/guc-cc-p2.pl
+++ b/gass/copy/source/test/guc-cc-p2.pl
@@ -1,3 +1,4 @@
 #!/usr/bin/perl
-system('./guc-cc.pl -p 2');
+use File::Basename;
+system(dirname($0) . '/guc-cc.pl -p 2');
 exit($? >> 8);

--- a/gass/copy/source/test/guc-cc-p2.pl
+++ b/gass/copy/source/test/guc-cc-p2.pl
@@ -1,0 +1,3 @@
+#!/usr/bin/perl
+system('./guc-cc.pl -p 2');
+exit($? >> 8);

--- a/gass/copy/source/test/guc-cc-p4.pl
+++ b/gass/copy/source/test/guc-cc-p4.pl
@@ -1,3 +1,4 @@
 #!/usr/bin/perl
-system('./guc-cc.pl -p 4');
+use File::Basename;
+system(dirname($0) . '/guc-cc.pl -p 4');
 exit($? >> 8);

--- a/gass/copy/source/test/guc-cc-p4.pl
+++ b/gass/copy/source/test/guc-cc-p4.pl
@@ -1,0 +1,3 @@
+#!/usr/bin/perl
+system('./guc-cc.pl -p 4');
+exit($? >> 8);

--- a/gass/copy/source/test/guc-cc-stripe-p4.pl
+++ b/gass/copy/source/test/guc-cc-stripe-p4.pl
@@ -1,0 +1,3 @@
+#!/usr/bin/perl
+system('./guc-cc.pl -stripe -p 4');
+exit($? >> 8);

--- a/gass/copy/source/test/guc-cc-stripe-p4.pl
+++ b/gass/copy/source/test/guc-cc-stripe-p4.pl
@@ -1,3 +1,4 @@
 #!/usr/bin/perl
-system('./guc-cc.pl -stripe -p 4');
+use File::Basename;
+system(dirname($0) . '/guc-cc.pl -stripe -p 4');
 exit($? >> 8);

--- a/gass/copy/source/test/guc-cc-stripe.pl
+++ b/gass/copy/source/test/guc-cc-stripe.pl
@@ -1,0 +1,3 @@
+#!/usr/bin/perl
+system('./guc-cc.pl -stripe');
+exit($? >> 8);

--- a/gass/copy/source/test/guc-cc-stripe.pl
+++ b/gass/copy/source/test/guc-cc-stripe.pl
@@ -1,3 +1,4 @@
 #!/usr/bin/perl
-system('./guc-cc.pl -stripe');
+use File::Basename;
+system(dirname($0) . '/guc-cc.pl -stripe');
 exit($? >> 8);

--- a/gass/copy/source/test/guc-cc.pl
+++ b/gass/copy/source/test/guc-cc.pl
@@ -35,8 +35,7 @@ my $subject = $ENV{FTP_TEST_SUBJECT};
 my $server_cs = $ENV{FTP_TEST_CONTACT};
 my $path_transform_with_cygpath_w = $ENV{CYGPATH_W_DEFINED};
 
-my @mode = ([], ["-fast"], ["-p", "2"], ["-p", "4"], ["-stripe"],
-    ["-stripe", "-p", "4"]);
+my @mode = @ARGV;
 
 my $dc_opt = [];
 $dc_opt = ["-subject", $subject] if $subject;
@@ -102,12 +101,11 @@ sub transform_path
     return $out;
 }
 
-my $test_count = 2*scalar(@mode)*scalar(@concur);
+my $test_count = 2*scalar(@concur);
 plan tests => $test_count;
 
 SKIP: {
     skip "Missing URL or subject", $test_count unless($server_cs && $subject);
-    foreach my $mode (@mode)
     {
         my $p=$_;
         my $server_port = $server_cs;
@@ -121,7 +119,7 @@ SKIP: {
             my ($out, $err);
             my ($pid, $rc);
             my @args = ("globus-url-copy-noinst",
-                @{$mode}, @{$cc}, @{$dc_opt},
+                @mode, @{$cc}, @{$dc_opt},
                 "-cd", "-r", $src_url, $dst_url);
             $errfd = gensym;
 
@@ -144,7 +142,7 @@ SKIP: {
                 print STDERR "# stderr:\n$err" if $err;
             }
 
-            ok($rc == 0, join(" ", "guc cc", @{$mode}, @{$cc},
+            ok($rc == 0, join(" ", "guc cc", @mode, @{$cc},
                 ,"exits with 0"));
 
             $errfd = gensym;
@@ -165,7 +163,7 @@ SKIP: {
                 print STDERR "# stderr:\n$err" if $err;
             }
 
-            ok($rc == 0, join(" ", "guc cc diff ", @{$mode}, @{$cc}));
+            ok($rc == 0, join(" ", "guc cc diff ", @mode, @{$cc}));
             rmtree("$work_dir/GL2");
         }
     }

--- a/packaging/debian/globus-gass-copy/debian/changelog.in
+++ b/packaging/debian/globus-gass-copy/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gass-copy (10.3-1+gct.@distro@) @distro@; urgency=medium
+
+  * Split guc-cc.pl test into smaller tests
+
+ -- Mattias Ellert <mattias.ellert@physica.uu.se>  Mon, 03 Sep 2018 21:32:56 +0200
+
 globus-gass-copy (10.1-2+gct.@distro@) @distro@; urgency=medium
 
   * use 2048 bit keys to support openssl 1.1.1

--- a/packaging/fedora/globus-gass-copy.spec
+++ b/packaging/fedora/globus-gass-copy.spec
@@ -3,7 +3,7 @@
 Name:		globus-gass-copy
 %global soname 2
 %global _name %(tr - _ <<< %{name})
-Version:	10.2
+Version:	10.3
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gass Copy
 
@@ -170,6 +170,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Mon Sep 03 2018 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.3-1
+- Split guc-cc.pl test into smaller tests
+
 * Fri Aug 24 2018 Globus Toolkit <support@globus.org> - 10.2-1
 - use 2048 bit keys to support openssl 1.1.1
 


### PR DESCRIPTION
The guc-cc.pl in the globus-gass-copy package take a long time to run on slow computers, and after the increase of the RSA key size used for testing it takes even longer.

The official Debian build servers have a test to detect stuck builds that kills a build if it hasn't printed anything to stdout/stderr for 150 minutes (2½ hours). When running the test suite the output from the test is redirected to various log files and only at the end of the test a status is written to stdout.

With the longer execution time due to the larger key size, the execution time of the guc-cc.pl test exceeds 2½ hours on the slower Debian build servers (has happened on hppa, armhf and mips builds).

This PR splits the guc-cc.pl into 6 smaller tests. The same tests are performed as with the original version, but since it is split into smaller tests the time between the output of the test status line is cut by a factor 6 and the no-activity test is not triggered on the slower build servers.
