### PR TITLE
Architecture independent package should not depend on libtool

### DIFF
--- a/gram/jobmanager/scripts/configure.ac
+++ b/gram/jobmanager/scripts/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gram_job_manager_scripts],[7.0],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gram_job_manager_scripts],[7.1],[https://github.com/gridcf/gct/issues])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])
 AC_SUBST([AGE_VERSION], [3])
@@ -8,7 +8,6 @@ AC_SUBST([PACKAGE_DEPS], [""])
 
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([1.11 foreign parallel-tests tar-pax])
-LT_INIT([dlopen win32-dll])
 
 m4_include([dirt.sh])
 AC_SUBST(DIRT_TIMESTAMP)

--- a/packaging/debian/globus-gram-job-manager-scripts/debian/changelog.in
+++ b/packaging/debian/globus-gram-job-manager-scripts/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gram-job-manager-scripts (7.1-1+gct.@distro@) @distro@; urgency=medium
+
+  * Architecture independent package should not depend on libtool
+
+ -- Mattias Ellert <mattias.ellert@physica.uu.se>  Fri, 21 Sep 2018 10:09:51 +0200
+
 globus-gram-job-manager-scripts (7.0-1+gct.@distro@) @distro@; urgency=medium
 
   * First Grid Community Toolkit release

--- a/packaging/fedora/globus-gram-job-manager-scripts.spec
+++ b/packaging/fedora/globus-gram-job-manager-scripts.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gram-job-manager-scripts
 %global _name %(tr - _ <<< %{name})
-Version:	7.0
+Version:	7.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GRAM Job ManagerScripts
 
@@ -87,6 +87,9 @@ make install DESTDIR=$RPM_BUILD_ROOT
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Fri Sep 21 2018 Mattias Ellert <mattias.ellert@physics.uu.se> - 7.1-1
+- Architecture independent package should not depend on libtool
+
 * Sat Mar 31 2018 Mattias Ellert <mattias.ellert@physics.uu.se> - 7.0-1
 - First Grid Community Toolkit release
 


### PR DESCRIPTION
Using LT_INIT in configure.ac results in the configure script checking for things that are not relevant for an architecture independent package, like the presence of a C compiler.

The other architecture independent packages already correctly do not use LT_INIT:
* gram/jobmanager/auditing/source/configure.ac
* gram/jobmanager/lrms/slurm/source/configure.ac
* gram/jobmanager/lrms/condor/source/configure.ac
* gsi/simple_ca/source/configure.ac
