### PR TITLE
Allow TLS 1.0/1.1

### DIFF
--- a/gsi/gssapi/source/configure.ac
+++ b/gsi/gssapi/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gssapi_gsi],[14.7],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gssapi_gsi],[14.8],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gsi/gssapi/source/library/gsi.conf
+++ b/gsi/gssapi/source/library/gsi.conf
@@ -2,7 +2,7 @@
 # Minimum TLS protocol version. One of TLS1_2_VERSION, TLS1_VERSION_DEPRECATED, 
 # TLS1_1_VERSION_DEPRECATED, or 0 for the default. Invalid values will use 
 # the default. SSLv3 and below are disabled.
-MIN_TLS_PROTOCOL=0
+MIN_TLS_PROTOCOL=TLS1_VERSION_DEPRECATED
 # Maximum TLS protocol version. One of TLS1_2_VERSION, TLS1_VERSION_DEPRECATED,
 # TLS1_1_VERSION_DEPRECATED, or 0 for the highest supported version. Invalid 
 # values will use the highest supported version. SSLv3 and below are disabled.

--- a/packaging/debian/globus-gssapi-gsi/debian/changelog.in
+++ b/packaging/debian/globus-gssapi-gsi/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gssapi-gsi (14.8-1+gct.@distro@) @distro@; urgency=medium
+
+  * Allow TLS 1.0/1.1
+
+ -- Mattias Ellert <mattias.ellert@physica.uu.se>  Fri, 21 Sep 2018 22:45:02 +0200
+
 globus-gssapi-gsi (14.7-1+gct.@distro@) @distro@; urgency=medium
 
   * Fix resource leak when loading cert directories

--- a/packaging/fedora/globus-gssapi-gsi.spec
+++ b/packaging/fedora/globus-gssapi-gsi.spec
@@ -3,7 +3,7 @@
 Name:		globus-gssapi-gsi
 %global soname 4
 %global _name %(tr - _ <<< %{name})
-Version:	14.7
+Version:	14.8
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GSSAPI library
 
@@ -154,6 +154,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Fri Sep 21 2018 Mattias Ellert <mattias.ellert@physics.uu.se> - 14.8-1
+- Allow TLS 1.0/1.1
+
 * Fri Aug 31 2018 Globus Toolkit <support@globus.org> - 14.7-1
 - Fix resource leak when loading cert directories
 


### PR DESCRIPTION
The old GT upstream changed the default minimum TLS version form 1.0 to 1.2 in their globus-gssapi-gsi version 13.9 (merged into GCT as our version 14.6).

There have been reports that this causes compatibility issues with some servers used in production in WLCG.

* https://ggus.eu/index.php?mode=ticket_info&ticket_id=137130
* https://mailman.egi.eu/pipermail/gt-eos/2018-September/000178.html

It was suggested that this change should be reverted, at least temporary. This PR sets the minimum TLS version to 1.0 in the gsi.conf configuration file.