### PR TITLE
Add su option to logrotate file

### DIFF
--- a/gram/jobmanager/source/configure.ac
+++ b/gram/jobmanager/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gram_job_manager],[15.3],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gram_job_manager],[15.4],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gram/jobmanager/source/gram.logrotate.in
+++ b/gram/jobmanager/source/gram.logrotate.in
@@ -8,4 +8,5 @@
     rotate 4
     sharedscripts
     copytruncate
+    su root root
 }

--- a/packaging/debian/globus-gram-job-manager/debian/changelog.in
+++ b/packaging/debian/globus-gram-job-manager/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gram-job-manager (15.4-1+gct.@distro@) @distro@; urgency=medium
+
+  * Add su option to logrotate file
+
+ -- Mattias Ellert <mattias.ellert@physica.uu.se>  Fri, 15 Feb 2019 16:11:09 +0100
+
 globus-gram-job-manager (15.3-1+gct.@distro@) @distro@; urgency=medium
 
   * Remove usage statistics collection support

--- a/packaging/fedora/globus-gram-job-manager.spec
+++ b/packaging/fedora/globus-gram-job-manager.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gram-job-manager
 %global _name %(tr - _ <<< %{name})
-Version:	15.3
+Version:	15.4
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GRAM Jobmanager
 
@@ -115,6 +115,11 @@ make install DESTDIR=$RPM_BUILD_ROOT
 # Remove libtool archives (.la files)
 rm $RPM_BUILD_ROOT%{_libdir}/*.la
 
+%if %{?rhel}%{!?rhel:0} == 6
+# Remove su option from logrotate file in EPEL 6 (not supported)
+sed '/ su /d' -i $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/globus-job-manager
+%endif
+
 %check
 GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 
@@ -153,6 +158,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %{_libdir}/libglobus_seg_job_manager.so
 
 %changelog
+* Fri Feb 15 2019 Mattias Ellert <mattias.ellert@physics.uu.se> - 15.4-1
+- Add su option to logrotate file
+
 * Fri Dec 07 2018 Mattias Ellert <mattias.ellert@physics.uu.se> - 15.3-1
 - Remove usage statistics collection support
 


### PR DESCRIPTION
This addresses failures to start logrotate on newer releases that requires the su option when the directory containing the files to be rotated have less strict access permissions:
```
● logrotate.service - Rotate log files
   Loaded: loaded (/lib/systemd/system/logrotate.service; static; vendor preset: enabled)
   Active: failed (Result: exit-code) since Wed 2019-02-13 15:40:11 CET; 46min ago
     Docs: man:logrotate(8)
           man:logrotate.conf(5)
  Process: 290 ExecStart=/usr/sbin/logrotate /etc/logrotate.conf (code=exited, status=1/FAILURE)
 Main PID: 290 (code=exited, status=1/FAILURE)

feb 13 15:40:02 debian-unstable systemd[1]: Starting Rotate log files...
feb 13 15:40:09 debian-unstable logrotate[290]: error: skipping "/var/log/globus/gram_*.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
feb 13 15:40:11 debian-unstable systemd[1]: logrotate.service: Main process exited, code=exited, status=1/FAILURE
feb 13 15:40:11 debian-unstable systemd[1]: logrotate.service: Failed with result 'exit-code'.
feb 13 15:40:11 debian-unstable systemd[1]: Failed to start Rotate log files.
```
