### PR TITLE
Make %_name definition be POSIX-compatible

### DIFF
--- a/packaging/fedora/globus-authz-callout-error.spec
+++ b/packaging/fedora/globus-authz-callout-error.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-authz-callout-error
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	4.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus authz error library

--- a/packaging/fedora/globus-authz.spec
+++ b/packaging/fedora/globus-authz.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-authz
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	4.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus authz library

--- a/packaging/fedora/globus-callout.spec
+++ b/packaging/fedora/globus-callout.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-callout
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	4.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Callout Library

--- a/packaging/fedora/globus-common.spec
+++ b/packaging/fedora/globus-common.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-common
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	18.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Common Library

--- a/packaging/fedora/globus-data-management-client.spec
+++ b/packaging/fedora/globus-data-management-client.spec
@@ -1,5 +1,5 @@
 Name:		globus-data-management-client
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.0
 Release:	2%{?dist}
 Summary:	Grid Community Toolkit - Data Management Client

--- a/packaging/fedora/globus-data-management-sdk.spec
+++ b/packaging/fedora/globus-data-management-sdk.spec
@@ -1,5 +1,5 @@
 Name:		globus-data-management-sdk
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.0
 Release:	2%{?dist}
 Summary:	Grid Community Toolkit - Data Management SDK

--- a/packaging/fedora/globus-data-management-server.spec
+++ b/packaging/fedora/globus-data-management-server.spec
@@ -1,5 +1,5 @@
 Name:		globus-data-management-server
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.0
 Release:	2%{?dist}
 Summary:	Grid Community Toolkit - Data Management Server

--- a/packaging/fedora/globus-ftp-client.spec
+++ b/packaging/fedora/globus-ftp-client.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-ftp-client
 %global soname 2
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	9.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GridFTP Client Library

--- a/packaging/fedora/globus-ftp-control.spec
+++ b/packaging/fedora/globus-ftp-control.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-ftp-control
 %global soname 1
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	9.4
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GridFTP Control Library

--- a/packaging/fedora/globus-gass-cache-program.spec
+++ b/packaging/fedora/globus-gass-cache-program.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-gass-cache-program
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	7.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Tools to manipulate local and remote GASS caches

--- a/packaging/fedora/globus-gass-cache.spec
+++ b/packaging/fedora/globus-gass-cache.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gass-cache
 %global soname 5
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	10.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gass Cache

--- a/packaging/fedora/globus-gass-copy.spec
+++ b/packaging/fedora/globus-gass-copy.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gass-copy
 %global soname 2
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	10.4
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gass Copy

--- a/packaging/fedora/globus-gass-server-ez.spec
+++ b/packaging/fedora/globus-gass-server-ez.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gass-server-ez
 %global soname 2
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gass Server_ez

--- a/packaging/fedora/globus-gass-transfer.spec
+++ b/packaging/fedora/globus-gass-transfer.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gass-transfer
 %global soname 2
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	9.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gass Transfer

--- a/packaging/fedora/globus-gatekeeper.spec
+++ b/packaging/fedora/globus-gatekeeper.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-gatekeeper
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	11.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gatekeeper

--- a/packaging/fedora/globus-gfork.spec
+++ b/packaging/fedora/globus-gfork.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gfork
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	5.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GFork

--- a/packaging/fedora/globus-gram-audit.spec
+++ b/packaging/fedora/globus-gram-audit.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-gram-audit
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	5.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GRAM Jobmanager Auditing

--- a/packaging/fedora/globus-gram-client-tools.spec
+++ b/packaging/fedora/globus-gram-client-tools.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gram-client-tools
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	12.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Job Management Tools (globusrun)

--- a/packaging/fedora/globus-gram-client.spec
+++ b/packaging/fedora/globus-gram-client.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gram-client
 %global soname 3
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	14.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GRAM Client Library

--- a/packaging/fedora/globus-gram-job-manager-callout-error.spec
+++ b/packaging/fedora/globus-gram-job-manager-callout-error.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gram-job-manager-callout-error
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	4.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GRAM Jobmanager Callout Errors

--- a/packaging/fedora/globus-gram-job-manager-condor.spec
+++ b/packaging/fedora/globus-gram-job-manager-condor.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-gram-job-manager-condor
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	3.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Condor Job Manager Support

--- a/packaging/fedora/globus-gram-job-manager-fork.spec
+++ b/packaging/fedora/globus-gram-job-manager-fork.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-gram-job-manager-fork
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	3.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Fork Job Manager Support

--- a/packaging/fedora/globus-gram-job-manager-lsf.spec
+++ b/packaging/fedora/globus-gram-job-manager-lsf.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-gram-job-manager-lsf
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	3.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - LSF Job Manager Support

--- a/packaging/fedora/globus-gram-job-manager-pbs.spec
+++ b/packaging/fedora/globus-gram-job-manager-pbs.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-gram-job-manager-pbs
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	3.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - PBS Job Manager Support

--- a/packaging/fedora/globus-gram-job-manager-scripts.spec
+++ b/packaging/fedora/globus-gram-job-manager-scripts.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-gram-job-manager-scripts
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	7.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GRAM Job ManagerScripts

--- a/packaging/fedora/globus-gram-job-manager-sge.spec
+++ b/packaging/fedora/globus-gram-job-manager-sge.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-gram-job-manager-sge
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	3.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Grid Engine Job Manager Support

--- a/packaging/fedora/globus-gram-job-manager-slurm.spec
+++ b/packaging/fedora/globus-gram-job-manager-slurm.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-gram-job-manager-slurm
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	3.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - SLURM Job Manager Support

--- a/packaging/fedora/globus-gram-job-manager.spec
+++ b/packaging/fedora/globus-gram-job-manager.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-gram-job-manager
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	15.4
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GRAM Jobmanager

--- a/packaging/fedora/globus-gram-protocol.spec
+++ b/packaging/fedora/globus-gram-protocol.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gram-protocol
 %global soname 3
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	13.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GRAM Protocol Library

--- a/packaging/fedora/globus-gram5.spec
+++ b/packaging/fedora/globus-gram5.spec
@@ -1,5 +1,5 @@
 Name:		globus-gram5
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.0
 Release:	2%{?dist}
 Summary:	Grid Community Toolkit - GRAM5 Bundle

--- a/packaging/fedora/globus-gridftp-server-control.spec
+++ b/packaging/fedora/globus-gridftp-server-control.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gridftp-server-control
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	8.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GridFTP Server Library

--- a/packaging/fedora/globus-gridftp-server.spec
+++ b/packaging/fedora/globus-gridftp-server.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gridftp-server
 %global soname 6
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	13.11
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GridFTP Server

--- a/packaging/fedora/globus-gridftp.spec
+++ b/packaging/fedora/globus-gridftp.spec
@@ -1,5 +1,5 @@
 Name:		globus-gridftp
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.0
 Release:	2%{?dist}
 Summary:	Grid Community Toolkit - GridFTP Bundle

--- a/packaging/fedora/globus-gridmap-callout-error.spec
+++ b/packaging/fedora/globus-gridmap-callout-error.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gridmap-callout-error
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	3.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gridmap Callout Errors

--- a/packaging/fedora/globus-gridmap-callout.spec
+++ b/packaging/fedora/globus-gridmap-callout.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-gridmap-callout
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	2.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gridmap Callout

--- a/packaging/fedora/globus-gridmap-eppn-callout.spec
+++ b/packaging/fedora/globus-gridmap-eppn-callout.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-gridmap-eppn-callout
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	2.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus gridmap ePPN callout

--- a/packaging/fedora/globus-gridmap-verify-myproxy-callout.spec
+++ b/packaging/fedora/globus-gridmap-verify-myproxy-callout.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-gridmap-verify-myproxy-callout
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	3.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus gridmap myproxy callout

--- a/packaging/fedora/globus-gsi-callback.spec
+++ b/packaging/fedora/globus-gsi-callback.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gsi-callback
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Callback Library

--- a/packaging/fedora/globus-gsi-cert-utils.spec
+++ b/packaging/fedora/globus-gsi-cert-utils.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gsi-cert-utils
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	10.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Cert Utils Library

--- a/packaging/fedora/globus-gsi-credential.spec
+++ b/packaging/fedora/globus-gsi-credential.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gsi-credential
 %global soname 1
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	8.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Credential Library

--- a/packaging/fedora/globus-gsi-openssl-error.spec
+++ b/packaging/fedora/globus-gsi-openssl-error.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gsi-openssl-error
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	4.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus OpenSSL Error Handling

--- a/packaging/fedora/globus-gsi-proxy-core.spec
+++ b/packaging/fedora/globus-gsi-proxy-core.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gsi-proxy-core
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	9.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Proxy Core Library

--- a/packaging/fedora/globus-gsi-proxy-ssl.spec
+++ b/packaging/fedora/globus-gsi-proxy-ssl.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gsi-proxy-ssl
 %global soname 1
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Proxy SSL Library

--- a/packaging/fedora/globus-gsi-sysconfig.spec
+++ b/packaging/fedora/globus-gsi-sysconfig.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gsi-sysconfig
 %global soname 1
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	9.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI System Config Library

--- a/packaging/fedora/globus-gsi.spec
+++ b/packaging/fedora/globus-gsi.spec
@@ -1,5 +1,5 @@
 Name:		globus-gsi
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.0
 Release:	3%{?dist}
 Summary:	Grid Community Toolkit - Security Tools

--- a/packaging/fedora/globus-gss-assist.spec
+++ b/packaging/fedora/globus-gss-assist.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gss-assist
 %global soname 3
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	12.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GSSAPI Assist library

--- a/packaging/fedora/globus-gssapi-error.spec
+++ b/packaging/fedora/globus-gssapi-error.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gssapi-error
 %global soname 2
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GSSAPI Error Library

--- a/packaging/fedora/globus-gssapi-gsi.spec
+++ b/packaging/fedora/globus-gssapi-gsi.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gssapi-gsi
 %global soname 4
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	14.10
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GSSAPI library

--- a/packaging/fedora/globus-io.spec
+++ b/packaging/fedora/globus-io.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-io
 %global soname 3
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	12.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - uniform I/O interface

--- a/packaging/fedora/globus-net-manager.spec
+++ b/packaging/fedora/globus-net-manager.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-net-manager
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	1.3
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Network Manager Library

--- a/packaging/fedora/globus-openssl-module.spec
+++ b/packaging/fedora/globus-openssl-module.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-openssl-module
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	5.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus OpenSSL Module Wrapper

--- a/packaging/fedora/globus-proxy-utils.spec
+++ b/packaging/fedora/globus-proxy-utils.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-proxy-utils
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	7.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Proxy Utility Programs

--- a/packaging/fedora/globus-resource-management-client.spec
+++ b/packaging/fedora/globus-resource-management-client.spec
@@ -1,5 +1,5 @@
 Name:		globus-resource-management-client
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.0
 Release:	3%{?dist}
 Summary:	Grid Community Toolkit - Resource Management Client Programs

--- a/packaging/fedora/globus-resource-management-sdk.spec
+++ b/packaging/fedora/globus-resource-management-sdk.spec
@@ -1,5 +1,5 @@
 Name:		globus-resource-management-sdk
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.0
 Release:	3%{?dist}
 Summary:	Grid Community Toolkit - Resource Management SDK

--- a/packaging/fedora/globus-resource-management-server.spec
+++ b/packaging/fedora/globus-resource-management-server.spec
@@ -1,5 +1,5 @@
 Name:		globus-resource-management-server
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.0
 Release:	3%{?dist}
 Summary:	Grid Community Toolkit - Resource Management Server Programs

--- a/packaging/fedora/globus-rsl.spec
+++ b/packaging/fedora/globus-rsl.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-rsl
 %global soname 2
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	11.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Resource Specification Language Library

--- a/packaging/fedora/globus-scheduler-event-generator.spec
+++ b/packaging/fedora/globus-scheduler-event-generator.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-scheduler-event-generator
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Scheduler Event Generator

--- a/packaging/fedora/globus-simple-ca.spec
+++ b/packaging/fedora/globus-simple-ca.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-simple-ca
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	5.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Simple CA Utility

--- a/packaging/fedora/globus-usage.spec
+++ b/packaging/fedora/globus-usage.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-usage
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	5.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Usage Library

--- a/packaging/fedora/globus-xio-gridftp-driver.spec
+++ b/packaging/fedora/globus-xio-gridftp-driver.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-xio-gridftp-driver
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	3.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus XIO GridFTP Driver

--- a/packaging/fedora/globus-xio-gridftp-multicast.spec
+++ b/packaging/fedora/globus-xio-gridftp-multicast.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-xio-gridftp-multicast
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	2.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus XIO GridFTP Multicast Driver

--- a/packaging/fedora/globus-xio-gsi-driver.spec
+++ b/packaging/fedora/globus-xio-gsi-driver.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-xio-gsi-driver
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	5.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus XIO GSI Driver

--- a/packaging/fedora/globus-xio-pipe-driver.spec
+++ b/packaging/fedora/globus-xio-pipe-driver.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-xio-pipe-driver
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	4.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Pipe Driver

--- a/packaging/fedora/globus-xio-popen-driver.spec
+++ b/packaging/fedora/globus-xio-popen-driver.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-xio-popen-driver
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	4.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus XIO Pipe Open Driver

--- a/packaging/fedora/globus-xio-rate-driver.spec
+++ b/packaging/fedora/globus-xio-rate-driver.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-xio-rate-driver
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	2.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus XIO Rate Limiting Driver

--- a/packaging/fedora/globus-xio-udt-driver.spec
+++ b/packaging/fedora/globus-xio-udt-driver.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-xio-udt-driver
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	2.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus XIO UDT Driver

--- a/packaging/fedora/globus-xio.spec
+++ b/packaging/fedora/globus-xio.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-xio
 %global soname 0
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	6.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus XIO Framework

--- a/packaging/fedora/globus-xioperf.spec
+++ b/packaging/fedora/globus-xioperf.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:		globus-xioperf
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:	5.0
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - XIO Performance Tool

--- a/packaging/fedora/gridftp-hdfs.spec
+++ b/packaging/fedora/gridftp-hdfs.spec
@@ -1,5 +1,5 @@
 Name:           gridftp-hdfs
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:        2.0
 Release:        1
 Summary:        HDFS DSI plugin for GridFTP

--- a/packaging/fedora/myproxy-oauth.spec
+++ b/packaging/fedora/myproxy-oauth.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 
 Name:           myproxy-oauth
-%global _name %(tr - _ <<< %{name})
+%global _name %(echo %{name} | tr - _)
 Version:        1.1
 Release:        1%{?dist}
 Summary:        MyProxy OAuth Delegation Serice


### PR DESCRIPTION
The `tr` is run with /bin/sh so on systems where /bin/sh is not bash, rpmbuild -bp fails.