### PR TITLE
Update documentation links to always point to the latest documentation

### DIFF
--- a/gridftp/server/src/configure.ac
+++ b/gridftp/server/src/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gridftp_server],[13.13],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gridftp_server],[13.14],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/packaging/debian/globus-gridftp-server/debian/changelog.in
+++ b/packaging/debian/globus-gridftp-server/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gridftp-server (13.14-1+gct.@distro@) @distro@; urgency=medium
+
+  * Update documentation links to always point to the latest documentation
+
+ -- Mattias Ellert <mattias.ellert@physica.uu.se>  Thu, 11 Apr 2019 21:34:25 +0200
+
 globus-gridftp-server (13.13-1+gct.@distro@) @distro@; urgency=medium
 
   * send markers in stream mode when requested by 'OPTS RETR Markers=n;'

--- a/packaging/debian/globus-xio-gsi-driver/debian/changelog.in
+++ b/packaging/debian/globus-xio-gsi-driver/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-xio-gsi-driver (5.2-1+gct.@distro@) @distro@; urgency=medium
+
+  * Update documentation links to always point to the latest documentation
+
+ -- Mattias Ellert <mattias.ellert@physica.uu.se>  Thu, 11 Apr 2019 21:35:37 +0200
+
 globus-xio-gsi-driver (5.1-1+gct.@distro@) @distro@; urgency=medium
 
   * Doxygen fixes

--- a/packaging/debian/globus-xio-gsi-driver/debian/copyright
+++ b/packaging/debian/globus-xio-gsi-driver/debian/copyright
@@ -5,12 +5,12 @@ Upstream-Contact: https://github.com/gridcf/gct/
 Files: *
 Copyright:
  1999-2017 University of Chicago
- 2018 Grid Community Forum
+ 2018-2019 Grid Community Forum
 License: Apache-2.0
 
 Files: debian/*
 Copyright:
- 2008-2018 Mattias Ellert <mattias.ellert@physics.uu.se>
+ 2008-2019 Mattias Ellert <mattias.ellert@physics.uu.se>
  2010-2013 Initiative for Globus in Europe (IGE), http://www.ige-project.eu/
 License: Apache-2.0
 

--- a/packaging/fedora/globus-gridftp-server.spec
+++ b/packaging/fedora/globus-gridftp-server.spec
@@ -3,7 +3,7 @@
 Name:		globus-gridftp-server
 %global soname 6
 %global _name %(echo %{name} | tr - _)
-Version:	13.13
+Version:	13.14
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GridFTP Server
 
@@ -217,6 +217,9 @@ fi
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Thu Apr 11 2019 Mattias Ellert <mattias.ellert@physics.uu.se> - 13.14-1
+- Update documentation links to always point to the latest documentation
+
 * Mon Apr 01 2019 Globus Toolkit <support@globus.org> - 13.13-1
 - send markers in stream mode when requested by 'OPTS RETR Markers=n;'
 

--- a/packaging/fedora/globus-xio-gsi-driver.spec
+++ b/packaging/fedora/globus-xio-gsi-driver.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-xio-gsi-driver
 %global _name %(echo %{name} | tr - _)
-Version:	5.1
+Version:	5.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus XIO GSI Driver
 
@@ -134,6 +134,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.la
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Thu Apr 11 2019 Mattias Ellert <mattias.ellert@physics.uu.se> - 5.2-1
+- Update documentation links to always point to the latest documentation
+
 * Wed Nov 21 2018 Mattias Ellert <mattias.ellert@physics.uu.se> - 5.1-1
 - Doxygen fixes
 

--- a/xio/drivers/gsi/configure.ac
+++ b/xio/drivers/gsi/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_xio_gsi_driver],[5.1],[https://github.com/gridcf/gct/issues/])
+AC_INIT([globus_xio_gsi_driver],[5.2],[https://github.com/gridcf/gct/issues/])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])


### PR DESCRIPTION
The documentation link update mostly changed files in packaging/, but it did change two files in the sources. Bump versions for those.