### PR TITLE
Fix openssl output format issue in sample-ca and gatekeeper startup script bug

### DIFF
--- a/gram/gatekeeper/source/init/globus-gatekeeper-lsb.in
+++ b/gram/gatekeeper/source/init/globus-gatekeeper-lsb.in
@@ -86,7 +86,7 @@ start()
         kflag=""
     fi
 
-    start_daemon -p "${GLOBUS_GATEKEEPER_PIDFILE}" \
+    start_daemon \
         ${GLOBUS_GATEKEEPER_NICE_LEVEL:+-n "${GLOBUS_GATEKEEPER_NICE_LEVEL}"} \
         "$prog" \
         -pidfile ${GLOBUS_GATEKEEPER_PIDFILE} \

--- a/gsi/simple_ca/source/grid-ca-sign.in
+++ b/gsi/simple_ca/source/grid-ca-sign.in
@@ -278,6 +278,7 @@ if test ${openssl_result} != 0; then
         for p in ${GRID_CA_DIR}/newcerts/*.pem; do
             subj_tmp_output=/tmp/tmp_output.$$
             "${openssl_cmd}" x509 -noout -subject -in $(construct_path ${p}) \
+                               -nameopt rfc2253,-dn_rev \
                                > ${subj_tmp_output} 2>&1
             res=$?
             if test $res != 0; then


### PR DESCRIPTION
Hello guys,

I have encountered an error that `grid-ca-sign` can not find existing cert like below:

![image](https://user-images.githubusercontent.com/19409802/56630354-b8e0cd00-6683-11e9-88ca-8e1e1f0ab783.png)

And when I checked the source code and  added some debug codes, I found there is a mistaken `sed` expression:

![image](https://user-images.githubusercontent.com/19409802/56630601-78ce1a00-6684-11e9-8f5a-3562a69dfd36.png)
![image](https://user-images.githubusercontent.com/19409802/56630709-c9de0e00-6684-11e9-8abc-be42809b8311.png)

    sed -e "s|subject= *|/|" -e "s|,|/|g"

The cert subject in cert.pem begins with "subject= /O=...". However, the sed expression will process this line incorrectly with one more "/" before the result like "//O=...", which will never match the "${req_subj}" starting with "/O=...". So the `if` expression will never work.

And  I just simply delete the "/" and the new `sed` expression is as below:

    sed -e "s|subject= *||" -e "s|,|/|g"

Hope this will help!
Thank you.