### PR TITLE
Keep peers in sync after SSL handshake failure in gssapi.

### DIFF
--- a/gsi/gssapi/source/library/init_sec_context.c
+++ b/gsi/gssapi/source/library/init_sec_context.c
@@ -554,7 +554,7 @@ GSS_CALLCONV gss_init_sec_context(
 
     gss_delete_sec_context(&local_minor_status, 
                            (gss_ctx_id_t *) &context,
-                           output_token);
+                           output_token->length == 0 ? output_token : GSS_C_NO_BUFFER);
     *context_handle_P = (gss_ctx_id_t) context;
  
  exit:


### PR DESCRIPTION
In gss_init_sec_context(), if globus_i_gsi_gss_handshake() returns an
error, the code attempts to fetch the output_token (if anyy) twice.
First in gss_init_sec_context() and again in gss_delete_sec_context().
The second fetch clobbers any data from the first fetch, so the client
never sends it.
The fix is to not pass output_token to gss_delete_sec_context() if it
already contains data.