### PR TITLE
Also use current tag in API documentation created by doxygen.

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1,5 +1,5 @@
 PROJECT_NAME           = "Grid Community Toolkit"
-PROJECT_NUMBER         = @VERSION@
+PROJECT_NUMBER         = "@VERSION@ (tag: @GCT_CURRENT_TAG@)"
 OPTIMIZE_OUTPUT_FOR_C  = YES
 GENERATE_MAN           = YES
 MAN_LINKS              = YES

--- a/configure.ac
+++ b/configure.ac
@@ -1,3 +1,14 @@
+m4_define([gct_current_tag], [m4_syscmd([
+if test -e .git ; then
+    git describe --tags > gct-current-tag.inc.new;
+    if ! cmp gct-current-tag.inc.new gct-current-tag.inc > /dev/null 2>&1; then
+        mv gct-current-tag.inc.new gct-current-tag.inc
+    else
+        rm gct-current-tag.inc.new
+    fi
+fi])dnl
+m4_[]include(gct-current-tag.inc)])dnl
+
 m4_define([globus_buildno], [m4_syscmd([
 if test -e .git ; then
     git log -n 1 --pretty=format:%ct > globus-version.inc.new;
@@ -20,6 +31,7 @@ syscmd([test -x ./prep-gsissh && sh -x ./prep-gsissh || true])
 syscmd([test -x ./write-globus-version && sh -x ./write-globus-version ]AC_PACKAGE_VERSION)
 m4_include([gsi_openssh/version.m4])
 AC_SUBST([GSI_OPENSSH_VERSION], [gsissh_version])
+AC_SUBST([GCT_CURRENT_TAG], gct_current_tag)
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([1.11 foreign parallel-tests tar-pax subdir-objects])
 AC_CONFIG_HEADERS([ltdlconfig.h])

--- a/doxygen/index.dox.in
+++ b/doxygen/index.dox.in
@@ -1,5 +1,5 @@
 /**
- * @mainpage Grid Community Toolkit API Documentation @VERSION@
+ * @mainpage Grid Community Toolkit API Documentation @VERSION@ (tag: @GCT_CURRENT_TAG@)
  *
  * @section gridftp_section GridFTP
  * - @ref globus_gass_copy


### PR DESCRIPTION
This adds a HTML header for the HTML API documentation created by doxygen which gets the "current" tag (i.e. what `git describe --tags` prints out, see DESCRIPTION in `git-describe(1)` for details) inserted after the "Globus" version number as `(tag: <CURRENT_TAG>)`.

The top of the API docs will then look like this:

![api-docs-header-with-current-tag-included](https://user-images.githubusercontent.com/4545897/57943625-c9781200-78d4-11e9-9197-3886f0ea0d3d.jpg)

...when `HEAD` doesn't point to a tagged version or just show a tag (e.g. `v6.2.20190226`) after `(tag: ` otherwise.

This PR derives from the discussion in https://github.com/gridcf/gct-docs/pull/9.

****

@matyasselmeci @ellert @msalle 
Could you please have a look into my modifcations to `configure.ac` and `Makefile.am`. I'm actually not really familiar with that stuff and just tried to "imitate" what saw in the files.

Instead of the `sed` command in the Makefile we could maybe also just use `configure` to make the replacement, but I don't yet know, how to do that. I assume the file to be changed (with `.in` as suffix) needs to be included somewhere in `configure.ac` and contain an e.g. @VARIABLE@ instead. Any help appreciated, I can then force-push the changes.

****

There is one issue with my changes: The first time I issue `autoreconf -i` to create `configure` I get a non-zero exit value:

```
[johndoe@centos-7x-x86-64 gct]$ time autoreconf -i
[...]
+ cat
configure.ac:32: error: possibly undefined macro: m4_include
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/bin/autoconf failed with exit status: 1

real	7m50.942s
user	6m6.586s
sys	0m50.597s

[johndoe@centos-7x-x86-64 gct]$ echo $?
1

[johndoe@centos-7x-x86-64 gct]$ sed -n '32p' < configure.ac
m4_include([gsi_openssh/version.m4])
```

...but re-issuing the same command afterwards actually works:

```
[johndoe@centos-7x-x86-64 gct]$ time autoreconf -i
[...]
+ cat
configure.ac:43: installing 'build-aux/compile'
configure.ac:39: installing 'build-aux/config.guess'
configure.ac:39: installing 'build-aux/config.sub'
configure.ac:36: installing 'build-aux/install-sh'
configure.ac:36: installing 'build-aux/missing'
libltdl/Makefile.am: installing 'build-aux/depcomp'

real	7m5.515s
user	5m24.904s
sys	0m48.267s
[johndoe@centos-7x-x86-64 gct]$ echo $?
0
```

Without the modification (at 6dbb77120bf85d2972dcaa69f5dbf54bf5e7d260) it worked at the first try. I'm unsure why as I don't recognize the relation.