### PR TITLE
Don't package /etc/grid-security/certificates

### DIFF
--- a/packaging/debian/globus-gsi-sysconfig/debian/changelog.in
+++ b/packaging/debian/globus-gsi-sysconfig/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gsi-sysconfig (9.2-2+gct.@distro@) @distro@; urgency=medium
+
+  * Don't package /etc/grid-security/certificates
+
+ -- Frank Scheiner <scheiner@hlrs.de>  Tue, 27 Aug 2019 14:25:43 +0200
+
 globus-gsi-sysconfig (9.2-1+gct.@distro@) @distro@; urgency=medium
 
   * Doxygen fixes

--- a/packaging/debian/globus-gsi-sysconfig/debian/libglobus-gsi-sysconfig1.install
+++ b/packaging/debian/globus-gsi-sysconfig/debian/libglobus-gsi-sysconfig1.install
@@ -1,3 +1,2 @@
 debian/tmp/usr/lib/*/libglobus_gsi_sysconfig.so.*
 debian/tmp/etc/grid-security
-debian/tmp/etc/grid-security/certificates

--- a/packaging/debian/globus-gsi-sysconfig/debian/rules
+++ b/packaging/debian/globus-gsi-sysconfig/debian/rules
@@ -77,7 +77,7 @@ install: build-stamp
 	rm $(INSTALLDIR)$(_docdir)/GLOBUS_LICENSE
 
 	# Create config directory
-	mkdir -p $(INSTALLDIR)/etc/grid-security/certificates
+	mkdir -p $(INSTALLDIR)/etc/grid-security
 
 binary: binary-arch binary-indep
 

--- a/packaging/fedora/globus-gsi-sysconfig.spec
+++ b/packaging/fedora/globus-gsi-sysconfig.spec
@@ -4,7 +4,7 @@ Name:		globus-gsi-sysconfig
 %global soname 1
 %global _name %(echo %{name} | tr - _)
 Version:	9.2
-Release:	1%{?dist}
+Release:	2%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI System Config Library
 
 Group:		System Environment/Libraries
@@ -113,7 +113,7 @@ make install DESTDIR=$RPM_BUILD_ROOT
 rm $RPM_BUILD_ROOT%{_libdir}/*.la
 
 # Create config directory
-mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/grid-security/certificates
+mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/grid-security
 
 %check
 make %{?_smp_mflags} check VERBOSE=1
@@ -126,7 +126,6 @@ make %{?_smp_mflags} check VERBOSE=1
 %defattr(-,root,root,-)
 %{_libdir}/libglobus_gsi_sysconfig.so.*
 %dir %{_sysconfdir}/grid-security
-%dir %{_sysconfdir}/grid-security/certificates
 %dir %{_pkgdocdir}
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
@@ -145,6 +144,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Wed Jun 19 2019 Mátyás Selmeci <matyas@cs.wisc.edu> - 9.2-2
+- Don't package /etc/grid-security/certificates
+
 * Wed Nov 21 2018 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.2-1
 - Doxygen fixes
 


### PR DESCRIPTION
There isn't much point to globus-gsi-sysconfig providing an empty /etc/grid-security/certificates directory, and putting it in the package causes problems for people that already have it, e.g. as a symlink to a shared filesystem.