### PR TITLE
Update additional old document references

### DIFF
--- a/gsi/cert_utils/source/programs/grid-cert-info.in
+++ b/gsi/cert_utils/source/programs/grid-cert-info.in
@@ -81,7 +81,7 @@ ${short_usage}
 EOF
 }
 
-# See http://www-unix.globus.org/toolkit/docs/4.0/admin/docbook/ch05.html#prewsaa-env-credentials
+# See https://gridcf.org/gct-docs/latest/gsic/pi/index.html#gsic-pi-env
 find_default_credential()
 {
     if [ -n "$X509_USER_CERT" ]; then

--- a/gsi/cert_utils/source/programs/grid-change-pass-phrase.in
+++ b/gsi/cert_utils/source/programs/grid-change-pass-phrase.in
@@ -66,7 +66,7 @@ if ! "$openssl" version > /dev/null 2> /dev/null; then
     exit 1
 fi
 
-# See http://www-unix.globus.org/toolkit/docs/4.0/admin/docbook/ch05.html#prewsaa-env-credentials
+# See https://gridcf.org/gct-docs/latest/gsic/pi/index.html#gsic-pi-env
 find_default_key()
 {
     if [ -n "$X509_USER_KEY" ]; then

--- a/packaging/debian/gridftp-hdfs/debian/README
+++ b/packaging/debian/gridftp-hdfs/debian/README
@@ -1,22 +1,22 @@
 This package is part of the GridFTP component
-of the Globus Toolkit. For more information visit:
+of the Grid Community Toolkit. For more information visit:
 
-http://www.globus.org/toolkit/docs/latest-stable/gridftp/
+https://gridcf.org/gct-docs/latest/gridftp/
 
 Admin Guide:
-http://www.globus.org/toolkit/docs/latest-stable/gridftp/admin/
+https://gridcf.org/gct-docs/latest/gridftp/admin/
 
 Developer's Guide:
-http://www.globus.org/toolkit/docs/latest-stable/gridftp/developer/
+https://gridcf.org/gct-docs/latest/gridftp/developer/
 
 Release Notes:
-http://www.globus.org/toolkit/docs/latest-stable/gridftp/rn/
+https://gridcf.org/gct-docs/latest/gridftp/rn/
 
 Public Interface Guide:
-http://www.globus.org/toolkit/docs/latest-stable/gridftp/pi/
+https://gridcf.org/gct-docs/latest/gridftp/pi/
 
 Quality Profile:
-http://www.globus.org/toolkit/docs/latest-stable/gridftp/qp/
+https://gridcf.org/gct-docs/latest/gridftp/qp/
 
 Migrating Guide:
-http://www.globus.org/toolkit/docs/latest-stable/gridftp/mig/
+https://gridcf.org/gct-docs/latest/gridftp/mig/

--- a/packaging/debian/gsi-openssh/debian/README
+++ b/packaging/debian/gsi-openssh/debian/README
@@ -1,22 +1,21 @@
-This package is part of of the Globus Toolkit. For more information visit:
+This package is part of the Grid Community Toolkit. For more information visit:
 
-http://www.globus.org/toolkit/docs/latest-stable/security/openssh/
+https://gridcf.org/gct-docs/latest/gsiopenssh/
 
 Admin Guide:
-http://www.globus.org/toolkit/docs/latest-stable/security/openssh/admin/
+https://gridcf.org/gct-docs/latest/gsiopenssh/admin/
 
 Developer's Guide:
-http://www.globus.org/toolkit/docs/latest-stable/security/openssh/developer/
+https://gridcf.org/gct-docs/latest/gsiopenssh/developer/
 
 Release Notes:
-http://www.globus.org/toolkit/docs/latest-stable/data/gridftp/rn/
-http://www.globus.org/toolkit/docs/latest-stable/security/openssh/rn/
+https://gridcf.org/gct-docs/latest/gsiopenssh/rn/
 
 Public Interface Guide:
-http://www.globus.org/toolkit/docs/latest-stable/security/openssh/pi/
+https://gridcf.org/gct-docs/latest/gsiopenssh/pi/
 
 Quality Profile:
-http://www.globus.org/toolkit/docs/latest-stable/security/openssh/qp/
+https://gridcf.org/gct-docs/latest/gsiopenssh/qp/
 
 Migrating Guide:
-http://www.globus.org/toolkit/docs/latest-stable/security/openssh/mig/
+https://gridcf.org/gct-docs/latest/gsiopenssh/mig/


### PR DESCRIPTION
This fixes the remaining old document references from the list on https://github.com/gridcf/gct/issues/12#issuecomment-437045059.

****

Regarding the document from the old www-unix.globus.org site, looking into
https://web.archive.org/web/20100209082809/http://www-unix.globus.org/toolkit/docs/4.0/admin/docbook/ch05.html#s-prewsaa-env
https://gridcf.org/gct-docs/latest/gsic/pi/index.html#gsic-pi-env seems to
be the appropriate replacement.