### PR TITLE
Avoid unknown secondary groups in test. Causes failures on launchpad.

### DIFF
--- a/gridftp/server/src/configure.ac
+++ b/gridftp/server/src/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gridftp_server],[13.18],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gridftp_server],[13.19],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gridftp/server/src/globus_i_gfs_data.c
+++ b/gridftp/server/src/globus_i_gfs_data.c
@@ -4651,9 +4651,14 @@ globus_l_gfs_data_authorize(
     op->session_handle->uid = pwent->pw_uid;
     op->session_handle->gid = pwent->pw_gid;
     op->session_handle->gid_count = getgroups(0, NULL);
-    op->session_handle->gid_array = (gid_t *) globus_malloc(
-        op->session_handle->gid_count * sizeof(gid_t));
-    getgroups(op->session_handle->gid_count, op->session_handle->gid_array);
+    if (op->session_handle->gid_count > 0)
+    {
+        op->session_handle->gid_array = (gid_t *) globus_malloc(
+            op->session_handle->gid_count * sizeof(gid_t));
+        op->session_handle->gid_count =
+            getgroups(op->session_handle->gid_count,
+                      op->session_handle->gid_array);
+    }
 #endif
 
     op->session_handle->username = globus_libc_strdup(session_info->username);
@@ -11669,9 +11674,14 @@ globus_i_gfs_data_session_start(
         op->session_handle->uid = getuid();
         op->session_handle->gid = getgid();
         op->session_handle->gid_count = getgroups(0, NULL);
-        op->session_handle->gid_array = (gid_t *) globus_malloc(
-            op->session_handle->gid_count * sizeof(gid_t));
-        getgroups(op->session_handle->gid_count, op->session_handle->gid_array);
+        if (op->session_handle->gid_count > 0)
+        {
+            op->session_handle->gid_array = (gid_t *) globus_malloc(
+                op->session_handle->gid_count * sizeof(gid_t));
+            op->session_handle->gid_count =
+                getgroups(op->session_handle->gid_count,
+                          op->session_handle->gid_array);
+        }
 
         op->session_handle->username = 
             globus_libc_strdup(session_info->username);

--- a/packaging/debian/globus-gridftp-server/debian/changelog.in
+++ b/packaging/debian/globus-gridftp-server/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gridftp-server (13.19-1+gct.@distro@) @distro@; urgency=medium
+
+  * Avoid unknown secondary groups in test. Causes failures on launchpad
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Mon, 22 Jul 2019 15:52:49 +0200
+
 globus-gridftp-server (13.18-1+gct.@distro@) @distro@; urgency=medium
 
   * Add support for supported checksum advertising

--- a/packaging/fedora/globus-gridftp-server.spec
+++ b/packaging/fedora/globus-gridftp-server.spec
@@ -3,7 +3,7 @@
 Name:		globus-gridftp-server
 %global soname 6
 %global _name %(echo %{name} | tr - _)
-Version:	13.18
+Version:	13.19
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GridFTP Server
 
@@ -223,6 +223,9 @@ fi
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Mon Jul 22 2019 Mattias Ellert <mattias.ellert@physics.uu.se> - 13.19-1
+- Avoid unknown secondary groups in test. Causes failures on launchpad
+
 * Fri Jun 07 2019 Globus Toolkit <support@globus.org> - 13.18-1
 - Add support for supported checksum advertising
 - Add support for SHA1, SHA256, SHA512 to POSIX DSI


### PR DESCRIPTION
See discussion in #95 and #96.
