### PR TITLE
Document guc/dcpriv behaviour with servers not supporting DC encryption

### DIFF
--- a/gass/copy/source/configure.ac
+++ b/gass/copy/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gass_copy],[10.4],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gass_copy],[10.5],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gass/copy/source/globus-url-copy.1
+++ b/gass/copy/source/globus-url-copy.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: globus-url-copy
 .\"    Author: [see the "AUTHOR" section]
-.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 03/31/2018
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 07/25/2019
 .\"    Manual: Grid Community Toolkit Manual
 .\"    Source: Grid Community Toolkit 6
 .\"  Language: English
 .\"
-.TH "GLOBUS\-URL\-COPY" "1" "03/31/2018" "Grid Community Toolkit 6" "Grid Community Toolkit Manual"
+.TH "GLOBUS\-URL\-COPY" "1" "07/25/2019" "Grid Community Toolkit 6" "Grid Community Toolkit Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -196,6 +196,22 @@ Set data channel protection mode to SAFE
 \fB\-dcpriv, \-data\-channel\-private\fR
 .RS 4
 Set data channel protection mode to PRIVATE
+.RE
+.if n \{\
+.sp
+.\}
+.RS 4
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+\fBWarning\fR
+.ps -1
+.br
+.sp
+Despite having \-dcpriv in its command line globus\-url\-copy will silently fall back to an unencryted data channel when connected to a server that does not support data channel encryption (e\&.g\&. dCache)!
+.sp .5v
 .RE
 .PP
 \fB\-off, \-partial\-offset\fR

--- a/gass/copy/source/globus-url-copy.txt
+++ b/gass/copy/source/globus-url-copy.txt
@@ -147,6 +147,10 @@ OPTIONS
 *-dcpriv, -data-channel-private*::
     Set data channel protection mode to PRIVATE
 
+WARNING: Despite having -dcpriv in its command line globus-url-copy
+will silently fall back to an unencryted data channel when connected
+to a server that does not support data channel encryption (e.g. dCache)!
+
 *-off, -partial-offset*::
     Offset for partial ftp file transfers, defaults to 0.
 

--- a/packaging/debian/globus-gass-copy/debian/changelog.in
+++ b/packaging/debian/globus-gass-copy/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gass-copy (10.5-1+gct.@distro@) @distro@; urgency=medium
+
+  * Document guc/dcpriv behaviour with servers not supporting DC encryption
+
+ -- Frank Scheiner <scheiner@hlrs.de>  Thu, 25 Jul 2019 17:58:31 +0200
+
 globus-gass-copy (10.4-1+gct.@distro@) @distro@; urgency=medium
 
   * Doxygen fixes

--- a/packaging/fedora/globus-gass-copy.spec
+++ b/packaging/fedora/globus-gass-copy.spec
@@ -3,7 +3,7 @@
 Name:		globus-gass-copy
 %global soname 2
 %global _name %(echo %{name} | tr - _)
-Version:	10.4
+Version:	10.5
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gass Copy
 
@@ -170,6 +170,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Thu Jul 25 2019 Frank Scheiner <scheiner@hlrs.de> - 10.5-1
+- Document guc/dcpriv behaviour with servers not supporting DC encryption
+
 * Wed Nov 21 2018 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.4-1
 - Doxygen fixes
 


### PR DESCRIPTION
Until we find a way to "fix" the problem described in #62 w/o breaking other functionality in the GridFTP server and client(s) this PR puts a warning into the guc manpage which - together with the apparently known fact (as per #69) that dCache does not support data channel encryption - hopefully prevents user from falling into that trap.

****
@ellert 
* I changed the text version of the manpage and the manpage directly, is there a tool I could use instead?
* Does this change also require a version number change for the gass-copy packages (in the spec and debian packaging files)? I'd say yes, but am unsure. If you agree, I can add these changes to this PR.