### PR TITLE
Disallow TLS 1.0/1.1 by default again

### DIFF
--- a/gsi/gssapi/source/configure.ac
+++ b/gsi/gssapi/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gssapi_gsi],[14.11],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gssapi_gsi],[14.12],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gsi/gssapi/source/library/gsi.conf
+++ b/gsi/gssapi/source/library/gsi.conf
@@ -2,7 +2,7 @@
 # Minimum TLS protocol version. One of TLS1_2_VERSION, TLS1_VERSION_DEPRECATED, 
 # TLS1_1_VERSION_DEPRECATED, or 0 for the default. Invalid values will use 
 # the default. SSLv3 and below are disabled.
-MIN_TLS_PROTOCOL=TLS1_VERSION_DEPRECATED
+MIN_TLS_PROTOCOL=0
 # Maximum TLS protocol version. One of TLS1_2_VERSION, TLS1_VERSION_DEPRECATED,
 # TLS1_1_VERSION_DEPRECATED, or 0 for the highest supported version. Invalid 
 # values will use the highest supported version. SSLv3 and below are disabled.

--- a/packaging/debian/globus-gssapi-gsi/debian/changelog.in
+++ b/packaging/debian/globus-gssapi-gsi/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gssapi-gsi (14.12-1+gct.@distro@) @distro@; urgency=medium
+
+  * Disallow TLS 1.0/1.1 by default again
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 13 Sep 2019 11:50:42 +0200
+
 globus-gssapi-gsi (14.11-1+gct.@distro@) @distro@; urgency=medium
 
   * Keep peers in sync after SSL handshake failure in gssapi

--- a/packaging/fedora/globus-gssapi-gsi.spec
+++ b/packaging/fedora/globus-gssapi-gsi.spec
@@ -3,7 +3,7 @@
 Name:		globus-gssapi-gsi
 %global soname 4
 %global _name %(echo %{name} | tr - _)
-Version:	14.11
+Version:	14.12
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GSSAPI library
 
@@ -154,6 +154,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Fri Sep 13 2019 Mattias Ellert <mattias.ellert@physics.uu.se> - 14.12-1
+- Disallow TLS 1.0/1.1 by default again
+
 * Fri May 17 2019 Mattias Ellert - 14.11-1
 - Keep peers in sync after SSL handshake failure in gssapi
 


### PR DESCRIPTION
Following @maarten-litmaath's comment on #55, that the setting for what TLS versions are enabled by default could now be restored to only allow 1.2, I have created this PR to do that.

A similar question. What about the change in #19. Can that be reverted too now? Or is it still relevant?