### PR TITLE
Make makefiles exit sooner on errors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,9 +16,8 @@ $(GT_ALL_TARGETS_INSTALL):
 $(GT_TARGETS_CHECK):
 	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) check || exit 1
 $(GT_ALL_TARGETS_DIST):
-	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && MAKEFLAGS= $(MAKE) $(AM_MAKEFLAGS) dist && \
-	$(MKDIR_P) package-output && \
-	cp $($@_SUBDIR)/$($@-tarball) package-output || exit 1
+	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && MAKEFLAGS= $(MAKE) $(AM_MAKEFLAGS) dist || exit 1
+	@$(MKDIR_P) package-output && cp $($@_SUBDIR)/$($@-tarball) package-output || exit 1
 
 $(GT_ALL_STAMPS):
 	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; ( (cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) all) && touch $@) || exit 1

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,22 +8,22 @@ DIST_SUBDIRS = @TOP_DIST_SUBDIRS@
 
 $(GT_TARGETS_CLEAN):
 	@if [ -f $($@_stamp) ]; then \
-		export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) clean || exit 1 ; \
+		export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) clean ; \
 	fi
 	@rm -f $($@_stamp)
 $(GT_ALL_TARGETS_INSTALL):
-	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) install || exit 1
+	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) install
 $(GT_TARGETS_CHECK):
-	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) check || exit 1
+	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) check
 $(GT_ALL_TARGETS_DIST):
-	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && MAKEFLAGS= $(MAKE) $(AM_MAKEFLAGS) dist || exit 1
-	@$(MKDIR_P) package-output && cp $($@_SUBDIR)/$($@-tarball) package-output || exit 1
+	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && MAKEFLAGS= $(MAKE) $(AM_MAKEFLAGS) dist
+	@$(MKDIR_P) package-output && cp $($@_SUBDIR)/$($@-tarball) package-output
 
 $(GT_ALL_STAMPS):
-	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; ( (cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) all) && touch $@) || exit 1
+	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; (cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) all) && touch $@
 
 $(GT_ONLY):
-	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) all || exit 1
+	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) all
 
 RPMDIRS = BUILD BUILDROOT RPMS SOURCES SPECS SRPMS
 
@@ -46,7 +46,7 @@ RPMDIRS = BUILD BUILDROOT RPMS SOURCES SPECS SRPMS
 
 
 $(GT_ALL_TARGETS_RPM): .rpmmacros
-	@for d in $(RPMDIRS); do mkdir -p rpmbuild/$$d; done
+	@for d in $(RPMDIRS); do mkdir -p rpmbuild/$$d || exit 1; done
 	@cp $($@_SOURCE) rpmbuild/SOURCES
 	@HOME=$$(pwd) ac_cv_host=$(host_triplet) rpmbuild --target=$(host_triplet) -ba $($@_SPECFILE)
 
@@ -67,11 +67,11 @@ $(GT_ALL_TARGETS_OSX_PKG):
 		echo "Processing $$filename"; \
 		for lib in `otool -L "$$filename" | sed 1d | grep -E "$(libdir)|ltdl" | awk '{print $$1}'`; do \
 		    echo "Rewriting $$lib"; \
-                    libname="$$(echo "$$lib" | sed -e 's|//*|/|g' -e 's|${libdir}//*||')"; \
-		    install_name_tool -change "$$lib" "@loader_path/../lib/$$libname" $$filename; \
-	       	done; \
+		    libname="$$(echo "$$lib" | sed -e 's|//*|/|g' -e 's|${libdir}//*||')"; \
+		    install_name_tool -change "$$lib" "@loader_path/../lib/$$libname" $$filename || exit 1; \
+		done; \
 		if basename $$filename | grep -vq '^lib'; then \
-		    install_name_tool -add_rpath "@loader_path/../lib" $$filename; \
+		    install_name_tool -add_rpath "@loader_path/../lib" "$$filename"; \
 		else \
 		    install_name_tool -id "$$(basename $$filename)" "$$filename"; \
 		fi; \
@@ -80,11 +80,11 @@ $(GT_ALL_TARGETS_OSX_PKG):
 	@find osx/dest/$$(basename $($@) .pkg) \( -name '*.la' -o -name '*.a' \) -a -exec rm {} +
 	@mkdir -p osx/packages
 	@pkgbuild --root $(abs_builddir)/osx/dest/$$(basename $($@) .pkg) \
-            --version $($($@)_PACKAGE_VERSION) \
+	    --version $($($@)_PACKAGE_VERSION) \
 	    --identifier org.globus.$($($@)_PACKAGE_NAME) \
-            --ownership recommended \
+	    --ownership recommended \
 	    $($($($@)_PACKAGE_NAME)_macosx_scripts) \
-            $($@)
+	    $($@)
 
 if !HAVE_LTDL
 LTDL_MAC_PKG = ltdl-@LTDL_VERSION@.pkg
@@ -103,8 +103,8 @@ rpm-pkgs: $(GT_TARGETS_RPM)
 tarballs: $(GT_ALL_TARGETS_DIST)
 
 DOC_STAMPS =
-DOC_PHONY = 
-DOC_CLEAN = 
+DOC_PHONY =
+DOC_CLEAN =
 if ENABLE_DOXYGEN
 DOC_STAMPS += doc-stamp
 DOC_CLEAN += doc-clean
@@ -122,13 +122,13 @@ endif
 install-data-local: $(DOC_STAMPS)
 	@if test -d doc/man/man3; then \
 		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
-		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 || exit 1 ; \
+		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
 	fi
 	@if test -d doc/html; then \
-		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1 ; \
+		for dir in `cd doc; find html -type d`; do \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
-		for f in `(cd doc; find html -type f)`; do \
+		for f in `cd doc; find html -type f`; do \
 			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f || exit 1; \
 		done ; \
 	fi
@@ -160,18 +160,18 @@ check-local:
 
 libltdl-install:
 if !HAVE_LTDL
-	PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd libltdl; $(MAKE) $(AM_MAKEFLAGS) install || exit 1
+	export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd libltdl && $(MAKE) $(AM_MAKEFLAGS) install
 endif
 	:
 libltdl-stamp:
 if !HAVE_LTDL
-	PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd libltdl; $(MAKE) $(AM_MAKEFLAGS) || exit 1
+	export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd libltdl && $(MAKE) $(AM_MAKEFLAGS)
 endif
 	touch $@
 
 if !HAVE_LTDL
 libltdl-clean:
-	PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; if [ -f libltdl/Makefile ]; then cd libltdl; $(MAKE) $(AM_MAKEFLAGS) clean || exit 1 ; fi
+	export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; if [ -f libltdl/Makefile ]; then cd libltdl && $(MAKE) $(AM_MAKEFLAGS) clean ; fi
 	rm -f libltdl-stamp
 endif
 
@@ -179,11 +179,11 @@ endif
 # We'll preserve the output from the prep-gsissh so that
 # configuration will work without re-downloading the sources
 dist-hook:
-	$(MKDIR_P) $(distdir)/gsi_openssh $(distdir)/packaging/package-output && \
-	$(INSTALL) -p $(srcdir)/prep-gsissh $(distdir) && \
-	$(INSTALL) -p $(srcdir)/packaging/package-output/* $(distdir)/packaging/package-output && \
-	(cd $(distdir); ./prep-gsissh;) && \
-	(if [ ! -d $(distdir)/gridftp/hdfs ]; then cp -pPR $(srcdir)/gridftp/hdfs $(distdir)/gridftp/hdfs; fi ) || exit 1
+	$(MKDIR_P) $(distdir)/gsi_openssh $(distdir)/packaging/package-output
+	$(INSTALL) -p $(srcdir)/prep-gsissh $(distdir)
+	$(INSTALL) -p $(srcdir)/packaging/package-output/* $(distdir)/packaging/package-output
+	cd $(distdir) && ./prep-gsissh
+	if [ ! -d $(distdir)/gridftp/hdfs ]; then cp -pPR $(srcdir)/gridftp/hdfs $(distdir)/gridftp/hdfs; fi
 
 globus_gridftp_server-stamp: $(GT_ENABLED_XIO_DRIVERS)
 .PHONY: $(GT_TARGETS_ALL) $(GT_TARGETS_ONLY) $(GT_TARGETS_CLEAN) $(GT_TARGETS_INSTALL) $(GT_TARGETS_CHECK) $(GT_TARGETS_DISTCLEAN) $(GT_TARGETS_DIST) $(DOC_PHONY) $(GT_TARGETS_RPM) $(GT_TARGETS_DEB) $(GT_BUNDLES)

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,23 +8,23 @@ DIST_SUBDIRS = @TOP_DIST_SUBDIRS@
 
 $(GT_TARGETS_CLEAN):
 	@if [ -f $($@_stamp) ]; then \
-		export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) clean ; \
+		export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) clean || exit 1 ; \
 	fi
 	@rm -f $($@_stamp)
 $(GT_ALL_TARGETS_INSTALL):
-	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) install
+	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) install || exit 1
 $(GT_TARGETS_CHECK):
-	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) check
+	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) check || exit 1
 $(GT_ALL_TARGETS_DIST):
-	@$(MKDIR_P) package-output
-	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && MAKEFLAGS= $(MAKE) $(AM_MAKEFLAGS) dist
-	@cp $($@_SUBDIR)/$($@-tarball) package-output
+	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && MAKEFLAGS= $(MAKE) $(AM_MAKEFLAGS) dist && \
+	@$(MKDIR_P) package-output && \
+	@cp $($@_SUBDIR)/$($@-tarball) package-output || exit 1
 
 $(GT_ALL_STAMPS):
 	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; ( (cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) all) && touch $@) || exit 1
 
 $(GT_ONLY):
-	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) all
+	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) all || exit 1
 
 RPMDIRS = BUILD BUILDROOT RPMS SOURCES SPECS SRPMS
 
@@ -122,15 +122,15 @@ endif
 
 install-data-local: $(DOC_STAMPS)
 	@if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
-		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
+		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 || exit 1 ; \
 	fi
 	@if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1 ; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f || exit 1; \
 		done ; \
 	fi
 
@@ -138,7 +138,7 @@ install-exec-local:
 	@for stamp in $(GT_ALL_STAMPS); do \
 	    if [ -f $$stamp ]; then \
 		stamp_pkg=`echo $$stamp | sed -e s'/-stamp//'`; \
-	        export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; $(MAKE) $(AM_MAKEFLAGS) $${stamp_pkg}-install ; \
+	        export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; $(MAKE) $(AM_MAKEFLAGS) $${stamp_pkg}-install || exit 1 ; \
 	    fi; \
 	done
 EXTRA_DIST = globus-vararg-enums-doxygen-filter.pl GLOBUS_LICENSE osx/resources/GLOBUS_LICENSE osx/resources/logo.png
@@ -155,24 +155,24 @@ check-local:
 	@for stamp in $(GT_ALL_STAMPS); do \
 	    if [ -f $$stamp ]; then \
 		stamp_pkg=`echo $$stamp | sed -e s'/-stamp//'`; \
-	        export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; $(MAKE) $(AM_MAKEFLAGS) $${stamp_pkg}-check ; \
+	        export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; $(MAKE) $(AM_MAKEFLAGS) $${stamp_pkg}-check || exit 1 ; \
 	    fi; \
 	done
 
 libltdl-install:
 if !HAVE_LTDL
-	PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd libltdl; $(MAKE) $(AM_MAKEFLAGS) install
+	PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd libltdl; $(MAKE) $(AM_MAKEFLAGS) install || exit 1
 endif
 	:
 libltdl-stamp:
 if !HAVE_LTDL
-	PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd libltdl; $(MAKE) $(AM_MAKEFLAGS)
+	PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd libltdl; $(MAKE) $(AM_MAKEFLAGS) || exit 1
 endif
 	touch $@
 
 if !HAVE_LTDL
 libltdl-clean:
-	PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; if [ -f libltdl/Makefile ]; then cd libltdl; $(MAKE) $(AM_MAKEFLAGS) clean; fi
+	PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; if [ -f libltdl/Makefile ]; then cd libltdl; $(MAKE) $(AM_MAKEFLAGS) clean || exit 1 ; fi
 	rm -f libltdl-stamp
 endif
 
@@ -180,11 +180,11 @@ endif
 # We'll preserve the output from the prep-gsissh so that
 # configuration will work without re-downloading the sources
 dist-hook:
-	$(MKDIR_P) $(distdir)/gsi_openssh $(distdir)/packaging/package-output
-	$(INSTALL) -p $(srcdir)/prep-gsissh $(distdir)
-	$(INSTALL) -p $(srcdir)/packaging/package-output/* $(distdir)/packaging/package-output
-	(cd $(distdir); ./prep-gsissh;)
-	(if [ ! -d $(distdir)/gridftp/hdfs ]; then cp -pPR $(srcdir)/gridftp/hdfs $(distdir)/gridftp/hdfs; fi )
+	$(MKDIR_P) $(distdir)/gsi_openssh $(distdir)/packaging/package-output && \
+	$(INSTALL) -p $(srcdir)/prep-gsissh $(distdir) && \
+	$(INSTALL) -p $(srcdir)/packaging/package-output/* $(distdir)/packaging/package-output && \
+	(cd $(distdir); ./prep-gsissh;) && \
+	(if [ ! -d $(distdir)/gridftp/hdfs ]; then cp -pPR $(srcdir)/gridftp/hdfs $(distdir)/gridftp/hdfs; fi ) || exit 1
 
 globus_gridftp_server-stamp: $(GT_ENABLED_XIO_DRIVERS)
 .PHONY: $(GT_TARGETS_ALL) $(GT_TARGETS_ONLY) $(GT_TARGETS_CLEAN) $(GT_TARGETS_INSTALL) $(GT_TARGETS_CHECK) $(GT_TARGETS_DISTCLEAN) $(GT_TARGETS_DIST) $(DOC_PHONY) $(GT_TARGETS_RPM) $(GT_TARGETS_DEB) $(GT_BUNDLES)

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,8 +17,8 @@ $(GT_TARGETS_CHECK):
 	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) check || exit 1
 $(GT_ALL_TARGETS_DIST):
 	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; cd $($@_SUBDIR) && MAKEFLAGS= $(MAKE) $(AM_MAKEFLAGS) dist && \
-	@$(MKDIR_P) package-output && \
-	@cp $($@_SUBDIR)/$($@-tarball) package-output || exit 1
+	$(MKDIR_P) package-output && \
+	cp $($@_SUBDIR)/$($@-tarball) package-output || exit 1
 
 $(GT_ALL_STAMPS):
 	@export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) ; ( (cd $($@_SUBDIR) && $(MAKE) $(AM_MAKEFLAGS) all) && touch $@) || exit 1

--- a/callout/source/library/Makefile.am
+++ b/callout/source/library/Makefile.am
@@ -36,14 +36,14 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f || exit 1 ; \
 		done ; \
 	fi

--- a/common/source/library/Makefile.am
+++ b/common/source/library/Makefile.am
@@ -205,14 +205,14 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
 	fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f || exit 1; \
 		done ; \
 	fi

--- a/gass/cache/source/Makefile.am
+++ b/gass/cache/source/Makefile.am
@@ -37,15 +37,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f || exit 1; \
 		done ; \
 	fi
 

--- a/gass/copy/source/Makefile.am
+++ b/gass/copy/source/Makefile.am
@@ -63,15 +63,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
 	fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f || exit 1; \
 		done ; \
 	fi
 

--- a/gass/transfer/source/library/Makefile.am
+++ b/gass/transfer/source/library/Makefile.am
@@ -43,14 +43,14 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi

--- a/gram/client/source/Makefile.am
+++ b/gram/client/source/Makefile.am
@@ -40,15 +40,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/gram/jobmanager/callout_error/Makefile.am
+++ b/gram/jobmanager/callout_error/Makefile.am
@@ -34,15 +34,15 @@ all-local: $(DOC_STAMPS)
 # Only install manpages that are prefixed by globus
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/gram/jobmanager/scheduler_event_generator/source/Makefile.am
+++ b/gram/jobmanager/scheduler_event_generator/source/Makefile.am
@@ -58,15 +58,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/gram/protocol/source/Makefile.am
+++ b/gram/protocol/source/Makefile.am
@@ -59,15 +59,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/gram/protocol/source/scripts/Makefile.am
+++ b/gram/protocol/source/scripts/Makefile.am
@@ -30,7 +30,7 @@ $(globusperl_DATA): create_protocol_constants.pl ../globus-gram-protocol-constan
 install-data-local: $(noinst_DATA)
 	$(mkinstalldirs) $(DESTDIR)$(MAN_DIR)
 	for manpage in $?; do \
-		$(INSTALL_DATA) $$manpage $(DESTDIR)$(MAN_DIR)/Globus::GRAM::`basename $$manpage`; \
+		$(INSTALL_DATA) $$manpage $(DESTDIR)$(MAN_DIR)/Globus::GRAM::`basename $$manpage` || exit 1; \
 	done
 
 all-local: $(globusperl_DATA)

--- a/gram/rsl/source/Makefile.am
+++ b/gram/rsl/source/Makefile.am
@@ -54,15 +54,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/gridftp/client/source/Makefile.am
+++ b/gridftp/client/source/Makefile.am
@@ -74,15 +74,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/gridftp/control/source/Makefile.am
+++ b/gridftp/control/source/Makefile.am
@@ -44,15 +44,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/gridftp/gridftp_driver/source/Makefile.am
+++ b/gridftp/gridftp_driver/source/Makefile.am
@@ -33,15 +33,15 @@ all-local: $(DOC_STAMPS)
 # Only install manpages that are prefixed by globus
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/gridftp/net_manager/Makefile.am
+++ b/gridftp/net_manager/Makefile.am
@@ -44,16 +44,16 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
-		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
+		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3  && \
 		rm -f $(DESTDIR)$(mandir)/man3/globus_xio_attr_cntl.3 ; \
 	fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/gsi/authz/error/Makefile.am
+++ b/gsi/authz/error/Makefile.am
@@ -35,15 +35,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/gsi/authz/source/Makefile.am
+++ b/gsi/authz/source/Makefile.am
@@ -39,15 +39,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/gsi/callback/source/library/Makefile.am
+++ b/gsi/callback/source/library/Makefile.am
@@ -41,14 +41,14 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
 	fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi

--- a/gsi/cert_utils/source/library/Makefile.am
+++ b/gsi/cert_utils/source/library/Makefile.am
@@ -36,14 +36,14 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
 	fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi

--- a/gsi/credential/source/library/Makefile.am
+++ b/gsi/credential/source/library/Makefile.am
@@ -36,14 +36,14 @@ all-local: $(DOC_STAMPS)
 # Only install manpages that are prefixed by globus
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi

--- a/gsi/gridmap_callout/error/Makefile.am
+++ b/gsi/gridmap_callout/error/Makefile.am
@@ -34,15 +34,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/gsi/gridmap_callout/source/Makefile.am
+++ b/gsi/gridmap_callout/source/Makefile.am
@@ -30,15 +30,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
 	fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/gsi/gss_assist/source/Makefile.am
+++ b/gsi/gss_assist/source/Makefile.am
@@ -56,15 +56,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/gsi/gssapi/source/library/Makefile.am
+++ b/gsi/gssapi/source/library/Makefile.am
@@ -87,14 +87,14 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi

--- a/gsi/gssapi_error/source/library/Makefile.am
+++ b/gsi/gssapi_error/source/library/Makefile.am
@@ -29,14 +29,14 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi

--- a/gsi/openssl_error/source/library/Makefile.am
+++ b/gsi/openssl_error/source/library/Makefile.am
@@ -29,14 +29,14 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi

--- a/gsi/openssl_module/source/library/Makefile.am
+++ b/gsi/openssl_module/source/library/Makefile.am
@@ -26,14 +26,14 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 	        $(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi

--- a/gsi/proxy/proxy_core/source/library/Makefile.am
+++ b/gsi/proxy/proxy_core/source/library/Makefile.am
@@ -40,15 +40,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
 	fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 EXTRA_DIST=sym

--- a/gsi/proxy/proxy_ssl/source/library/Makefile.am
+++ b/gsi/proxy/proxy_ssl/source/library/Makefile.am
@@ -32,14 +32,14 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
 	fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi

--- a/gsi/sysconfig/source/library/Makefile.am
+++ b/gsi/sysconfig/source/library/Makefile.am
@@ -33,14 +33,14 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
 	fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi

--- a/xio/drivers/gsi/Makefile.am
+++ b/xio/drivers/gsi/Makefile.am
@@ -35,15 +35,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
         fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 

--- a/xio/src/Makefile.am
+++ b/xio/src/Makefile.am
@@ -74,15 +74,15 @@ all-local: $(DOC_STAMPS)
 
 install-data-local: $(DOC_STAMPS)
 	if test -d doc/man/man3; then \
-		install -d -m 755 $(DESTDIR)$(mandir)/man3; \
+		install -d -m 755 $(DESTDIR)$(mandir)/man3 && \
 		$(INSTALL) -m 644 doc/man/man3/[Gg][Ll][Oo][Bb][Uu][Ss]*.3 $(DESTDIR)$(mandir)/man3 ; \
 	fi
 	if test -d doc/html; then \
 		for dir in `(cd doc; find html -type d)`; do \
-			install -d -m 755 $(DESTDIR)$(docdir)/$$dir; \
+			install -d -m 755 $(DESTDIR)$(docdir)/$$dir || exit 1; \
 		done ; \
 		for f in `(cd doc; find html -type f)`; do \
-			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f ; \
+			$(INSTALL) -m 644 doc/$$f $(DESTDIR)$(docdir)/$$f  || exit 1; \
 		done ; \
 	fi
 


### PR DESCRIPTION
This is based on #119 but only keeps the `|| exit 1` in for loops and uses `&&` in a few places instead.

The changes are also applied to all the Makefile.am files that have those constructions (mostly `install-data-local` targets).