### PR TITLE
Fix format for grid-cert-info -issuer

### DIFF
--- a/gsi/cert_utils/source/configure.ac
+++ b/gsi/cert_utils/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gsi_cert_utils], [10.5], [https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gsi_cert_utils], [10.6], [https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gsi/cert_utils/source/programs/grid-cert-info.in
+++ b/gsi/cert_utils/source/programs/grid-cert-info.in
@@ -210,7 +210,7 @@ while [ "X$1" != "X" ]; do
 	toprint="$toprint -issuer_hash"
 	;;
     -issuer|-i | --issuer)
-	toprint="$toprint -issuer"
+	toprint="$toprint ISSUER"
 	;;
     -startdate|-sd|--startdate)
 	toprint="$toprint -startdate"
@@ -249,19 +249,14 @@ fi
  
 if [ "$cert_format" = pkcs12 ]; then
     echo "Credentials are in pkcs12 format, OpenSSL will prompt for p12 password"
-    cert_data="`"$openssl" pkcs12 -nokeys -clcerts -nomacver -in ${certfile}`"
+    cert_data=`"$openssl" pkcs12 -nokeys -clcerts -nomacver -in ${certfile}`
     command_stub="\"$openssl\" x509 -noout $openssl_options"
 else
+    cert_data=""
     command_stub="\"$openssl\" x509 -noout -in ${certfile} $openssl_options"
 fi
 
-
-# Will probably need this...
-if [ "$cert_format" = pkcs12 ]; then
-    subject=`echo "$cert_data" | eval ${command_stub} -subject`
-else
-    subject=`eval ${command_stub} -subject`
-fi
+subject=`echo "$cert_data" | eval ${command_stub} -subject`
 
 if test $? -ne 0 ; then
     exit 1
@@ -270,6 +265,17 @@ fi
 subject=`echo ${subject} | sed 's%^subject=\ *%%'`
 if [ "${rfc2253:-0}" != 1 ]; then
     subject=$(echo "${subject}" | sed -e 's|^|/|' -e 's|,|/|g')
+fi
+
+issuer=`echo "$cert_data" | eval ${command_stub} -issuer`
+
+if test $? -ne 0 ; then
+    exit 1
+fi
+
+issuer=`echo ${issuer} | sed 's%^issuer=\ *%%'`
+if [ "${rfc2253:-0}" != 1 ]; then
+    issuer=$(echo "${issuer}" | sed -e 's|^|/|' -e 's|,|/|g')
 fi
 
 eval set -- "$toprint"
@@ -282,6 +288,8 @@ for i in "$@"; do
 	# Do not show the proxy levels
 	echo "${subject}" | sed -e 's%/CN=proxy%%g' -e 's%/CN=limited proxy%%g'
 	;;
+    ISSUER)
+	echo "${issuer}"
+	;;
     esac
 done
-

--- a/packaging/debian/globus-gsi-cert-utils/debian/changelog.in
+++ b/packaging/debian/globus-gsi-cert-utils/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gsi-cert-utils (10.6-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix format for grid-cert-info -issuer
+
+ -- Mattias Ellert <ellert@ellert.physics.uu.se>  Mon, 01 Jun 2020 21:00:36 +0200
+
 globus-gsi-cert-utils (10.5-1+gct.@distro@) @distro@; urgency=medium
 
   * Remove old replace-version.xsl file

--- a/packaging/fedora/globus-gsi-cert-utils.spec
+++ b/packaging/fedora/globus-gsi-cert-utils.spec
@@ -3,7 +3,7 @@
 Name:		globus-gsi-cert-utils
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	10.5
+Version:	10.6
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Cert Utils Library
 
@@ -180,6 +180,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Mon Jun 01 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.6-1
+- Fix format for grid-cert-info -issuer
+
 * Tue Mar 17 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.5-1
 - Remove old replace-version.xsl file
 


### PR DESCRIPTION
Old:
$ grid-cert-info -subject -issuer
/DC=org/DC=terena/DC=tcs/C=SE/O=Uppsala universitet/CN=Mattias Ellert mel03009@user.uu.se
C=NL,ST=Noord-Holland,L=Amsterdam,O=TERENA,CN=TERENA eScience Personal CA 3

New:
$ ~/grid-cert-info -subject -issuer
/DC=org/DC=terena/DC=tcs/C=SE/O=Uppsala universitet/CN=Mattias Ellert mel03009@user.uu.se
/C=NL/ST=Noord-Holland/L=Amsterdam/O=TERENA/CN=TERENA eScience Personal CA 3

I.e. issuer uses the same format as subject. (As it used to be with older openssl versions.)