### PR TITLE
Use sep_multiline to get the certificate subject and drop GPT support in simple CA

### DIFF
--- a/gass/copy/source/configure.ac
+++ b/gass/copy/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gass_copy],[10.6],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gass_copy],[10.7],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gass/copy/source/test/Makefile.am
+++ b/gass/copy/source/test/Makefile.am
@@ -69,7 +69,7 @@ check_DATA =  \
 	umask 022; $(OPENSSL) x509 -passin pass:globus -req -days 365 -in testcred.req -CA $*.cacert -CAkey $*.cakey -out $@
 
 .cert.gridmap:
-	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`; \
+	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n'`; \
 	echo "\"$$subject\" `id -un`" > $@
 
 if CYGPATH_W_DEFINED

--- a/gass/copy/source/test/Makefile.am
+++ b/gass/copy/source/test/Makefile.am
@@ -69,7 +69,7 @@ check_DATA =  \
 	umask 022; $(OPENSSL) x509 -passin pass:globus -req -days 365 -in testcred.req -CA $*.cacert -CAkey $*.cakey -out $@
 
 .cert.gridmap:
-	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt rfc2253,-dn_rev | sed -e 's/subject= */\//' -e 's/,/\//g'` ; \
+	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`; \
 	echo "\"$$subject\" `id -un`" > $@
 
 if CYGPATH_W_DEFINED
@@ -104,7 +104,7 @@ CLEANFILES = testcred.key testcred.cert testcred.req \
 	     testcred.cakey testcred.gridmap
 clean-local:
 	if [ -f testcred.link ]; then \
-	    rm -f "$$(cat testcred.link)" testcred.link; \
+	    rm -f $$(cat testcred.link) testcred.link; \
 	fi
 	if test -f testcred.signing_policy; then \
 	    rm -f $$(cat testcred.signing_policy) testcred.signing_policy; \

--- a/gass/copy/source/test/test-wrapper
+++ b/gass/copy/source/test/test-wrapper
@@ -37,7 +37,7 @@ if ($< != 0)
 {
     $server_args = "-no-fork $server_args";
 }
-$subject = `openssl x509 -subject -noout -in \${X509_USER_CERT:-testcred.cert} -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
+$subject = `openssl x509 -subject -noout -in \${X509_USER_CERT:-testcred.cert} -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\\s*!/!' | tr -d '\\n'`;
 
 $server_pid = open(SERVER, "$server_prog $server_args|");
  

--- a/gass/copy/source/test/test-wrapper
+++ b/gass/copy/source/test/test-wrapper
@@ -37,9 +37,7 @@ if ($< != 0)
 {
     $server_args = "-no-fork $server_args";
 }
-chomp($subject = `env OPENSSL_CONF=testcred.cnf openssl x509 -subject -noout -in \${X509_USER_CERT:-testcred.cert} -nameopt rfc2253,-dn_rev `);
-$subject =~ s/^subject= */\//;
-$subject =~ s/,/\//g;
+$subject = `openssl x509 -subject -noout -in \${X509_USER_CERT:-testcred.cert} -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
 
 $server_pid = open(SERVER, "$server_prog $server_args|");
  

--- a/gridftp/client/source/configure.ac
+++ b/gridftp/client/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_ftp_client],[9.4],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_ftp_client],[9.5],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gridftp/client/source/test/Makefile.am
+++ b/gridftp/client/source/test/Makefile.am
@@ -149,7 +149,7 @@ LOG_COMPILER = $(LIBTOOL) --mode=execute \
 	linkname="`$(OPENSSL) x509 -hash -noout -in $<`.0"; \
 	rm -f "$$linkname"; \
 	cp $< "$$linkname"; \
-        echo "$$linkname" > $@
+	echo "$$linkname" > $@
 
 .link.signing_policy:
 	linkname=`cat $<`; \
@@ -172,16 +172,16 @@ LOG_COMPILER = $(LIBTOOL) --mode=execute \
 	umask 022; $(OPENSSL) x509 -passin pass:globus -req -days 365 -in testcred.req -CA $*.cacert -CAkey $*.cakey -out $@
 
 .cert.gridmap:
-	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt rfc2253,-dn_rev | sed -e 's/subject= */\//' -e 's/,/\//g'` ; \
-        echo "\"$$subject\" `id -un`" > $@
+	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`; \
+	echo "\"$$subject\" `id -un`" > $@
 CLEANFILES = testcred.key testcred.cert testcred.req \
 	     testcred.cacert testcred.srl \
 	     testcred.cakey testcred.gridmap
 
 clean-local:
 	if [ -f testcred.link ]; then \
-            rm -f "$$(cat testcred.link)" testcred.link; \
-        fi
+	    rm -f $$(cat testcred.link) testcred.link; \
+	fi
 	if test -f testcred.signing_policy; then \
 	    rm -f $$(cat testcred.signing_policy) testcred.signing_policy; \
 	fi
@@ -192,4 +192,3 @@ EXTRA_DIST = \
 	$(check_DATA_real) \
 	$(check_SCRIPTS) \
 	$(EXTRA_SCRIPTS)
-

--- a/gridftp/client/source/test/Makefile.am
+++ b/gridftp/client/source/test/Makefile.am
@@ -172,7 +172,7 @@ LOG_COMPILER = $(LIBTOOL) --mode=execute \
 	umask 022; $(OPENSSL) x509 -passin pass:globus -req -days 365 -in testcred.req -CA $*.cacert -CAkey $*.cakey -out $@
 
 .cert.gridmap:
-	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`; \
+	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n'`; \
 	echo "\"$$subject\" `id -un`" > $@
 CLEANFILES = testcred.key testcred.cert testcred.req \
 	     testcred.cacert testcred.srl \

--- a/gridftp/client/source/test/get-test.pl
+++ b/gridftp/client/source/test/get-test.pl
@@ -219,7 +219,7 @@ if($ENV{GLOBUS_FTP_CLIENT_TEST_SUBJECT})
 }
 else
 {
-    $subject = `openssl x509 -in testcred.cert -subject -noout -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
+    $subject = `openssl x509 -in testcred.cert -subject -noout -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\\s*!/!' | tr -d '\\n'`;
 }
 
 

--- a/gridftp/client/source/test/get-test.pl
+++ b/gridftp/client/source/test/get-test.pl
@@ -219,9 +219,7 @@ if($ENV{GLOBUS_FTP_CLIENT_TEST_SUBJECT})
 }
 else
 {
-    chomp($subject = `openssl x509 -in testcred.cert -subject -noout -nameopt rfc2253,-dn_rev`);
-    $subject =~ s/^subject= */\//;
-    $subject =~ s/,/\//g;
+    $subject = `openssl x509 -in testcred.cert -subject -noout -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
 }
 
 

--- a/gridftp/client/source/test/put-test.pl
+++ b/gridftp/client/source/test/put-test.pl
@@ -228,7 +228,7 @@ if($ENV{GLOBUS_FTP_CLIENT_TEST_SUBJECT})
 }
 else
 {
-    $subject = `openssl x509 -in testcred.cert -subject -noout -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
+    $subject = `openssl x509 -in testcred.cert -subject -noout -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\\s*!/!' | tr -d '\\n'`;
 }
 
 push(@tests, "dcau_test('none', 0);");

--- a/gridftp/client/source/test/put-test.pl
+++ b/gridftp/client/source/test/put-test.pl
@@ -228,9 +228,7 @@ if($ENV{GLOBUS_FTP_CLIENT_TEST_SUBJECT})
 }
 else
 {
-    chomp($subject = `openssl x509 -in testcred.cert -subject -noout -nameopt rfc2253,-dn_rev`);
-    $subject =~ s/^subject= */\//;
-    $subject =~ s/,/\//g;
+    $subject = `openssl x509 -in testcred.cert -subject -noout -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
 }
 
 push(@tests, "dcau_test('none', 0);");

--- a/gridftp/client/source/test/test-wrapper
+++ b/gridftp/client/source/test/test-wrapper
@@ -39,7 +39,7 @@ if ($< != 0)
     $server_args = "-no-fork $server_args";
 }
 
-$subject = `openssl x509 -subject -noout -in \${X509_USER_CERT:-testcred.cert} -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
+$subject = `openssl x509 -subject -noout -in \${X509_USER_CERT:-testcred.cert} -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\\s*!/!' | tr -d '\\n'`;
 
 print STDERR "#Subject is $subject\n";
 print STDERR "#PATH is $ENV{PATH}\n";

--- a/gridftp/client/source/test/test-wrapper
+++ b/gridftp/client/source/test/test-wrapper
@@ -39,9 +39,7 @@ if ($< != 0)
     $server_args = "-no-fork $server_args";
 }
 
-chomp($subject = `openssl x509 -subject -noout -in \${X509_USER_CERT:-testcred.cert} -nameopt rfc2253,-dn_rev`);
-$subject =~ s/^subject= */\//;
-$subject =~ s/,/\//g;
+$subject = `openssl x509 -subject -noout -in \${X509_USER_CERT:-testcred.cert} -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
 
 print STDERR "#Subject is $subject\n";
 print STDERR "#PATH is $ENV{PATH}\n";

--- a/gridftp/client/source/test/transfer-test.pl
+++ b/gridftp/client/source/test/transfer-test.pl
@@ -257,9 +257,7 @@ if($ENV{GLOBUS_FTP_CLIENT_TEST_SUBJECT})
 }
 else
 {
-    chomp($subject = `openssl x509 -in testcred.cert -subject -noout -nameopt rfc2253,-dn_rev`);
-    $subject =~ s/^subject= */\//;
-    $subject =~ s/,/\//g;
+    $subject = `openssl x509 -in testcred.cert -subject -noout -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
 }
 
 push(@tests, "dcau_test('none', 0);");

--- a/gridftp/client/source/test/transfer-test.pl
+++ b/gridftp/client/source/test/transfer-test.pl
@@ -257,7 +257,7 @@ if($ENV{GLOBUS_FTP_CLIENT_TEST_SUBJECT})
 }
 else
 {
-    $subject = `openssl x509 -in testcred.cert -subject -noout -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
+    $subject = `openssl x509 -in testcred.cert -subject -noout -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\\s*!/!' | tr -d '\\n'`;
 }
 
 push(@tests, "dcau_test('none', 0);");

--- a/gridftp/control/source/configure.ac
+++ b/gridftp/control/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_ftp_control], [9.5], [https://github.com/gridcf/gct/issues])
+AC_INIT([globus_ftp_control], [9.6], [https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gridftp/control/source/test/Makefile.am
+++ b/gridftp/control/source/test/Makefile.am
@@ -113,7 +113,7 @@ LOG_COMPILER = $(LIBTOOL) --mode=execute $(GSI_DRIVER_DLOPEN)
 	umask 022; $(OPENSSL) x509 -passin pass:globus -req -days 365 -in testcred.req -CA $*.cacert -CAkey $*.cakey -out $@
 
 .cert.gridmap:
-	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`; \
+	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n'`; \
 	echo "\"$$subject\" `id -un`" > $@
 
 CLEANFILES = testcred.key testcred.cert testcred.req \

--- a/gridftp/control/source/test/Makefile.am
+++ b/gridftp/control/source/test/Makefile.am
@@ -90,7 +90,7 @@ LOG_COMPILER = $(LIBTOOL) --mode=execute $(GSI_DRIVER_DLOPEN)
 	linkname="`$(OPENSSL) x509 -hash -noout -in $<`.0"; \
 	rm -f "$$linkname"; \
 	cp $< "$$linkname"; \
-        echo "$$linkname" > $@
+	echo "$$linkname" > $@
 
 .link.signing_policy:
 	linkname=`cat $<`; \
@@ -113,17 +113,17 @@ LOG_COMPILER = $(LIBTOOL) --mode=execute $(GSI_DRIVER_DLOPEN)
 	umask 022; $(OPENSSL) x509 -passin pass:globus -req -days 365 -in testcred.req -CA $*.cacert -CAkey $*.cakey -out $@
 
 .cert.gridmap:
-	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt rfc2253,-dn_rev | sed -e 's/subject= */\//' -e 's/,/\//g'` ; \
-        echo "\"$$subject\" `id -un`" > $@
+	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`; \
+	echo "\"$$subject\" `id -un`" > $@
 
 CLEANFILES = testcred.key testcred.cert testcred.req \
 	     testcred.cacert testcred.srl \
 	     testcred.cakey testcred.gridmap \
-             get_lingering_close.sh.port
+	     get_lingering_close.sh.port
 clean-local:
 	if [ -f testcred.link ]; then \
-            rm -f $$(cat testcred.link) testcred.link; \
-        fi
+	    rm -f $$(cat testcred.link) testcred.link; \
+	fi
 	if test -f testcred.signing_policy; then \
 	    rm -f $$(cat testcred.signing_policy) testcred.signing_policy; \
 	fi

--- a/gridftp/gridftp_driver/source/configure.ac
+++ b/gridftp/gridftp_driver/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_xio_gridftp_driver],[3.3],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_xio_gridftp_driver],[3.4],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gridftp/gridftp_driver/source/test/Makefile.am
+++ b/gridftp/gridftp_driver/source/test/Makefile.am
@@ -38,7 +38,7 @@ LOG_COMPILER = $(LIBTOOL) --mode=execute \
 	linkname="`$(OPENSSL) x509 -hash -noout -in $<`.0"; \
 	rm -f "$$linkname"; \
 	cp $< "$$linkname"; \
-        echo "$$linkname" > $@
+	echo "$$linkname" > $@
 
 .link.signing_policy:
 	linkname=`cat $<`; \
@@ -61,8 +61,8 @@ LOG_COMPILER = $(LIBTOOL) --mode=execute \
 	umask 022; $(OPENSSL) x509 -passin pass:globus -req -days 365 -in testcred.req -CA $*.cacert -CAkey $*.cakey -out $@
 
 .cert.gridmap:
-	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt rfc2253,-dn_rev | sed -e 's/subject= */\//' -e 's/,/\//g'` ; \
-        echo "\"$$subject\" `id -un`" > $@
+	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`; \
+	echo "\"$$subject\" `id -un`" > $@
 
 SUFFIXES = .key .req .cert .srl .link .signing_policy .cacert .cakey .gridmap
 CLEANFILES = testcred.key testcred.cert testcred.req \
@@ -70,12 +70,11 @@ CLEANFILES = testcred.key testcred.cert testcred.req \
 	     testcred.cakey testcred.gridmap
 clean-local:
 	if [ -f testcred.link ]; then \
-            rm -f "$$(cat testcred.link)" testcred.link; \
-        fi
+	    rm -f $$(cat testcred.link) testcred.link; \
+	fi
 	if test -f testcred.signing_policy; then \
 	    rm -f $$(cat testcred.signing_policy) testcred.signing_policy; \
 	fi
 endif
 
 EXTRA_DIST = $(check_SCRIPTS) test-wrapper
-

--- a/gridftp/gridftp_driver/source/test/Makefile.am
+++ b/gridftp/gridftp_driver/source/test/Makefile.am
@@ -61,7 +61,7 @@ LOG_COMPILER = $(LIBTOOL) --mode=execute \
 	umask 022; $(OPENSSL) x509 -passin pass:globus -req -days 365 -in testcred.req -CA $*.cacert -CAkey $*.cakey -out $@
 
 .cert.gridmap:
-	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`; \
+	subject=`$(OPENSSL) x509 -subject -noout -in $< -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n'`; \
 	echo "\"$$subject\" `id -un`" > $@
 
 SUFFIXES = .key .req .cert .srl .link .signing_policy .cacert .cakey .gridmap

--- a/gridftp/gridftp_driver/source/test/test-wrapper
+++ b/gridftp/gridftp_driver/source/test/test-wrapper
@@ -38,9 +38,7 @@ my $server_args = "-no-chdir -d 0 -p $server_port $server_nosec";
 if ($< != 0) {
     $server_args = "-no-fork $server_args";
 }
-chomp($subject = `openssl x509 -in testcred.cert -subject -noout -nameopt rfc2253,-dn_rev`);
-$subject =~ s/^subject= */\//;
-$subject =~ s/,/\//g;
+$subject = `openssl x509 -in testcred.cert -subject -noout -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
 
 $server_pid = open(SERVER, "$server_prog $server_args |");
  

--- a/gridftp/gridftp_driver/source/test/test-wrapper
+++ b/gridftp/gridftp_driver/source/test/test-wrapper
@@ -38,7 +38,7 @@ my $server_args = "-no-chdir -d 0 -p $server_port $server_nosec";
 if ($< != 0) {
     $server_args = "-no-fork $server_args";
 }
-$subject = `openssl x509 -in testcred.cert -subject -noout -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
+$subject = `openssl x509 -in testcred.cert -subject -noout -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\\s*!/!' | tr -d '\\n'`;
 
 $server_pid = open(SERVER, "$server_prog $server_args |");
  

--- a/gsi/cert_utils/source/configure.ac
+++ b/gsi/cert_utils/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gsi_cert_utils], [10.6], [https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gsi_cert_utils], [10.7], [https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gsi/cert_utils/source/programs/grid-cert-info.in
+++ b/gsi/cert_utils/source/programs/grid-cert-info.in
@@ -102,12 +102,12 @@ certificate_format()
 
     if test "$testfile" = ""; then
         :
-    elif echo "$certfile" | grep '\.p12$' > /dev/null 2>&1 ; then
+    elif echo "$testfile" | grep '\.p12$' > /dev/null 2>&1 ; then
         _format=pkcs12
-    elif echo "$certfile" | grep '\.pem$' > /dev/null 2>&1 ; then
+    elif echo "$testfile" | grep '\.pem$' > /dev/null 2>&1 ; then
         _format=x509
     elif grep -- '-----BEGIN' "$testfile" > /dev/null 2>&1 ; then
-        _format="x509"
+        _format=x509
     else
         :
     fi
@@ -186,7 +186,7 @@ while [ "X$1" != "X" ]; do
         else
             echo "No DiRT information available."
         fi
-        exit 0;
+        exit 0
         ;;
     -file| -f | --file)
         if [ -n "$2" -a -f "$2" -a -r "$2" ]; then
@@ -230,66 +230,61 @@ while [ "X$1" != "X" ]; do
 done
 
 if [ "${rfc2253:-0}" != 1 ]; then
-    openssl_options="$openssl_options -nameopt rfc2253,-dn_rev"
+    openssl_options="$openssl_options -nameopt sep_multiline"
 fi
 cert_format=`certificate_format "$certfile"`
 if test "$cert_format" = ""; then
     echo "Error: Cannot locate certificate" 1>&2
-    exit 1;
+    exit 1
 fi
 
 if [ "X$toprint" = "X" ]; then
     toprint="-text"
 fi
 
-if [ ! \( -f "${certfile}" -a -r "${certfile}" \) ]; then
+if [ ! -r "${certfile}" ]; then
     echo "ERROR: Cannot read certificate file ${certfile}" >&2
     exit 1
 fi
  
 if [ "$cert_format" = pkcs12 ]; then
     echo "Credentials are in pkcs12 format, OpenSSL will prompt for p12 password"
-    cert_data=`"$openssl" pkcs12 -nokeys -clcerts -nomacver -in ${certfile}`
+    cert_data=`"$openssl" pkcs12 -nokeys -clcerts -nomacver -in "$certfile"`
     command_stub="\"$openssl\" x509 -noout $openssl_options"
 else
     cert_data=""
-    command_stub="\"$openssl\" x509 -noout -in ${certfile} $openssl_options"
+    command_stub="\"$openssl\" x509 -noout -in \"$certfile\" $openssl_options"
 fi
 
-subject=`echo "$cert_data" | eval ${command_stub} -subject`
-
-if test $? -ne 0 ; then
-    exit 1
-fi
-
-subject=`echo ${subject} | sed 's%^subject=\ *%%'`
-if [ "${rfc2253:-0}" != 1 ]; then
-    subject=$(echo "${subject}" | sed -e 's|^|/|' -e 's|,|/|g')
-fi
-
-issuer=`echo "$cert_data" | eval ${command_stub} -issuer`
-
-if test $? -ne 0 ; then
-    exit 1
-fi
-
-issuer=`echo ${issuer} | sed 's%^issuer=\ *%%'`
-if [ "${rfc2253:-0}" != 1 ]; then
-    issuer=$(echo "${issuer}" | sed -e 's|^|/|' -e 's|,|/|g')
-fi
+echo "$cert_data" | eval ${command_stub} || exit $?
 
 eval set -- "$toprint"
 for i in "$@"; do
     case "$i" in
     -*)
-	echo "$cert_data" | eval "{ ${command_stub} $i || exit $?; } | sed 's/^[a-zA-Z]*=[ ]*//'"
+	echo "$cert_data" | eval ${command_stub} $i | sed 's/^[a-zA-Z]*= *//'
 	;;
     SUBJECT)
+	if [ "${rfc2253:-0}" != 1 ]; then
+	    subject=`echo "$cert_data" | eval ${command_stub} -subject | \
+		sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
+	else
+	    subject=`echo "$cert_data" | eval ${command_stub} -subject | \
+		sed 's/^subject= *//'`
+	fi
 	# Do not show the proxy levels
 	echo "${subject}" | sed -e 's%/CN=proxy%%g' -e 's%/CN=limited proxy%%g'
 	;;
     ISSUER)
-	echo "${issuer}"
+	if [ "${rfc2253:-0}" != 1 ]; then
+	    issuer=`echo "$cert_data" | eval ${command_stub} -issuer | \
+		sed -e /^issuer=/d -e 's!^\s*!/!' | tr -d '\n'`
+	else
+	    issuer=`echo "$cert_data" | eval ${command_stub} -issuer | \
+		sed 's/^issuer= *//'`
+	fi
+	# Do not show the proxy levels
+	echo "${issuer}" | sed -e 's%/CN=proxy%%g' -e 's%/CN=limited proxy%%g'
 	;;
     esac
 done

--- a/gsi/cert_utils/source/programs/grid-cert-info.in
+++ b/gsi/cert_utils/source/programs/grid-cert-info.in
@@ -200,7 +200,7 @@ while [ "X$1" != "X" ]; do
         fi
         shift
         ;;
-    -all | -all)
+    -all | --all)
 	toprint="$toprint -text"
 	;;
     -subject|-s | --subject)
@@ -229,9 +229,6 @@ while [ "X$1" != "X" ]; do
     shift
 done
 
-if [ "${rfc2253:-0}" != 1 ]; then
-    openssl_options="$openssl_options -nameopt sep_multiline"
-fi
 cert_format=`certificate_format "$certfile"`
 if test "$cert_format" = ""; then
     echo "Error: Cannot locate certificate" 1>&2
@@ -239,6 +236,7 @@ if test "$cert_format" = ""; then
 fi
 
 if [ "X$toprint" = "X" ]; then
+    # If no specific information requested - print all
     toprint="-text"
 fi
 
@@ -266,8 +264,9 @@ for i in "$@"; do
 	;;
     SUBJECT)
 	if [ "${rfc2253:-0}" != 1 ]; then
-	    subject=`echo "$cert_data" | eval ${command_stub} -subject | \
-		sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
+	    subject=`echo "$cert_data" | \
+		eval ${command_stub} -subject -nameopt sep_multiline | \
+		sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n'`
 	else
 	    subject=`echo "$cert_data" | eval ${command_stub} -subject | \
 		sed 's/^subject= *//'`
@@ -277,8 +276,9 @@ for i in "$@"; do
 	;;
     ISSUER)
 	if [ "${rfc2253:-0}" != 1 ]; then
-	    issuer=`echo "$cert_data" | eval ${command_stub} -issuer | \
-		sed -e /^issuer=/d -e 's!^\s*!/!' | tr -d '\n'`
+	    issuer=`echo "$cert_data" | \
+		eval ${command_stub} -issuer -nameopt sep_multiline | \
+		sed -e '/^issuer=/d' -e 's!^\s*!/!' | tr -d '\n'`
 	else
 	    issuer=`echo "$cert_data" | eval ${command_stub} -issuer | \
 		sed 's/^issuer= *//'`

--- a/gsi/cert_utils/source/programs/grid-cert-request.in
+++ b/gsi/cert_utils/source/programs/grid-cert-request.in
@@ -196,7 +196,7 @@ set_non_default_ca()
         for cert in ${trusted_certs_dir}/*.0; do
             if test -r "${cert}" ; then
                 eval "CA${index}=${cert}"
-                TEMP_SUBJECT="$("$openssl" x509 -in ${cert} -noout -subject -nameopt rfc2253,-dn_rev | sed -e 's|^subject= *|/|' -e 's|,|/|g')"
+                TEMP_SUBJECT=`"$openssl" x509 -in ${cert} -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
                 eval "CA_SUBJECT${index}=\"${TEMP_SUBJECT}\""
                 eval "CA_HASH${index}=`"$openssl" x509 -in ${cert} -noout -hash`"
                 eval "echo \"$index)  \${CA_HASH${index}} - \${CA_SUBJECT${index}}\""
@@ -225,7 +225,7 @@ set_non_default_ca()
             echo 
             exit 1
         fi
-        TEMP_SUBJECT=`"$openssl" x509 -in ${trusted_certs_dir}/${CA_HASH}.0 -noout -subject -nameopt rfc2253,-dn_rev | sed -e 's|^subject= *|/|' -e 's|,|/|g'`
+        TEMP_SUBJECT=`"$openssl" x509 -in ${trusted_certs_dir}/${CA_HASH}.0 -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
         eval "CA_SUBJECT=\"${TEMP_SUBJECT}\""
     fi
 
@@ -789,13 +789,7 @@ create_certs () {
     #------------------------
     # Insert instructions into the request file
 
-
-    SUBJECT="$("$openssl" req -text -noout < ${REQ_OUTPUT} 2>&1 |\
-              grep 'Subject:' | awk -F: '{print $2}' |\
-              cut -c2- )"
-
-    #Convert the subject to the correct form.
-    SUBJECT=`echo "/"${SUBJECT} | sed -e 's|, |/|g'`
+    SUBJECT=`"$openssl" req -in ${REQ_OUTPUT} -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
 
     create_request_header >${REQ_HEAD}
 

--- a/gsi/cert_utils/source/programs/grid-cert-request.in
+++ b/gsi/cert_utils/source/programs/grid-cert-request.in
@@ -196,7 +196,7 @@ set_non_default_ca()
         for cert in ${trusted_certs_dir}/*.0; do
             if test -r "${cert}" ; then
                 eval "CA${index}=${cert}"
-                TEMP_SUBJECT=`"$openssl" x509 -in ${cert} -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
+                TEMP_SUBJECT=`"$openssl" x509 -in ${cert} -noout -subject -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n'`
                 eval "CA_SUBJECT${index}=\"${TEMP_SUBJECT}\""
                 eval "CA_HASH${index}=`"$openssl" x509 -in ${cert} -noout -hash`"
                 eval "echo \"$index)  \${CA_HASH${index}} - \${CA_SUBJECT${index}}\""
@@ -225,7 +225,7 @@ set_non_default_ca()
             echo 
             exit 1
         fi
-        TEMP_SUBJECT=`"$openssl" x509 -in ${trusted_certs_dir}/${CA_HASH}.0 -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
+        TEMP_SUBJECT=`"$openssl" x509 -in ${trusted_certs_dir}/${CA_HASH}.0 -noout -subject -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n'`
         eval "CA_SUBJECT=\"${TEMP_SUBJECT}\""
     fi
 
@@ -789,7 +789,7 @@ create_certs () {
     #------------------------
     # Insert instructions into the request file
 
-    SUBJECT=`"$openssl" req -in ${REQ_OUTPUT} -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
+    SUBJECT=`"$openssl" req -in ${REQ_OUTPUT} -noout -subject -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n'`
 
     create_request_header >${REQ_HEAD}
 

--- a/gsi/cert_utils/source/programs/grid-default-ca.in
+++ b/gsi/cert_utils/source/programs/grid-default-ca.in
@@ -22,7 +22,7 @@ find_ca_dir() {
     shift
 
     for x in "$@"; do
-        if test -f "$x/$cahash.0"; then
+        if test -r "$x/$cahash.0"; then
             echo "${x}"
             return 0
         fi
@@ -50,11 +50,11 @@ show_default() {
 
     DEFAULTCAHASH="NONE"
     gsconf=""
-    if test -f "${GRID_SECURITY_DIR}/grid-security.conf"; then
+    if test -r "${GRID_SECURITY_DIR}/grid-security.conf"; then
         gsconf=${GRID_SECURITY_DIR}/grid-security.conf
-    elif test -f "/etc/grid-security/grid-security.conf"; then
+    elif test -r "/etc/grid-security/grid-security.conf"; then
         gsconf="/etc/grid-security/grid-security.conf"
-    elif test -f "${sysconfdir}/grid-security.conf"; then
+    elif test -r "${sysconfdir}/grid-security.conf"; then
         gsconf="${sysconfdir}/grid-security.conf"
     fi
 
@@ -62,8 +62,8 @@ show_default() {
     DEFAULTCAHASH=`echo "$DEFAULTCACONFFILE" | sed -e "s|.*\.\(.*\)$|\1|"`
 
     for x in "$@"; do
-        if test -f "${x}/$DEFAULTCAHASH.0"; then
-            DEFAULT_SUBJECT="$("$openssl" x509 -in ${x}/$DEFAULTCAHASH.0 -noout -subject -nameopt rfc2253,-dn_rev| sed -e "s|subject= *|/|" -e "s|,|/|g")"
+        if test -r "${x}/$DEFAULTCAHASH.0"; then
+            DEFAULT_SUBJECT=`"$openssl" x509 -in ${x}/$DEFAULTCAHASH.0 -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
             echo
             echo "The default CA is: $DEFAULT_SUBJECT"
             echo "         Location: ${x}/$DEFAULTCAHASH.0"
@@ -91,7 +91,7 @@ ca_list() {
         for cert in ${cert_hashes}; do
             if test -r "${cert}" ; then 
                 eval "CA${index}=${cert}"
-                TEMP_SUBJECT="$("$openssl" x509 -in "${cert}" -noout -subject -nameopt rfc2253,-dn_rev| sed -e "s|subject= *|/|" -e "s|,|/|g")"
+                TEMP_SUBJECT=`"$openssl" x509 -in "${cert}" -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
                 eval "CA_SUBJECT${index}=\"${TEMP_SUBJECT}\""
                 TEMP_HASH=`echo ${cert} | sed -e  "s|.*/\([^/]*\)\.0|\1|"`
                 eval "CA_HASH${index}=$TEMP_HASH"
@@ -283,7 +283,7 @@ DIRT_BRANCH_ID="@DIRT_BRANCH_ID@"
 
 short_usage="$PROGRAM_NAME [-help] [ options ...]"
 
-if ! openssl version > /dev/null 2> /dev/null; then
+if ! "$openssl" version > /dev/null 2> /dev/null; then
     echo "Unable to locate openssl binary in $bindir or PATH" 1>&2
     exit 1
 fi
@@ -351,7 +351,7 @@ else
         echo 
         exit 1
     fi
-    CA_SUBJECT="$(openssl x509 -in "${CA_CERT}" -noout -subject -nameopt rfc2253,-dn_rev| sed -e "s|subject= *|/|" -e "s|,|/|g")"
+    CA_SUBJECT=`"$openssl" x509 -in "${CA_CERT}" -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
 fi
 
 secconfdir=`get_security_dir ${CA_CERT_DIR}`
@@ -369,7 +369,7 @@ echo
 echo "setting the default CA to: ${CA_SUBJECT}"
 echo
 
-NEW_DEFAULT_CA_HASH=`openssl x509 -in ${CA_CERT} -noout -hash`
+NEW_DEFAULT_CA_HASH=`"$openssl" x509 -in "${CA_CERT}" -noout -hash`
 
 GRID_SECURITY_FILE=${CA_CERT_DIR}/grid-security.conf.${NEW_DEFAULT_CA_HASH}
 CA_SSL_HOST_CONFIG_FILE=${CA_CERT_DIR}/globus-host-ssl.conf.${NEW_DEFAULT_CA_HASH}

--- a/gsi/cert_utils/source/programs/grid-default-ca.in
+++ b/gsi/cert_utils/source/programs/grid-default-ca.in
@@ -63,7 +63,7 @@ show_default() {
 
     for x in "$@"; do
         if test -r "${x}/$DEFAULTCAHASH.0"; then
-            DEFAULT_SUBJECT=`"$openssl" x509 -in ${x}/$DEFAULTCAHASH.0 -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
+            DEFAULT_SUBJECT=`"$openssl" x509 -in ${x}/$DEFAULTCAHASH.0 -noout -subject -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n'`
             echo
             echo "The default CA is: $DEFAULT_SUBJECT"
             echo "         Location: ${x}/$DEFAULTCAHASH.0"
@@ -91,7 +91,7 @@ ca_list() {
         for cert in ${cert_hashes}; do
             if test -r "${cert}" ; then 
                 eval "CA${index}=${cert}"
-                TEMP_SUBJECT=`"$openssl" x509 -in "${cert}" -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
+                TEMP_SUBJECT=`"$openssl" x509 -in "${cert}" -noout -subject -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n'`
                 eval "CA_SUBJECT${index}=\"${TEMP_SUBJECT}\""
                 TEMP_HASH=`echo ${cert} | sed -e  "s|.*/\([^/]*\)\.0|\1|"`
                 eval "CA_HASH${index}=$TEMP_HASH"
@@ -351,7 +351,7 @@ else
         echo 
         exit 1
     fi
-    CA_SUBJECT=`"$openssl" x509 -in "${CA_CERT}" -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
+    CA_SUBJECT=`"$openssl" x509 -in "${CA_CERT}" -noout -subject -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n'`
 fi
 
 secconfdir=`get_security_dir ${CA_CERT_DIR}`

--- a/gsi/simple_ca/source/configure.ac
+++ b/gsi/simple_ca/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_simple_ca],[5.1],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_simple_ca],[5.2],[https://github.com/gridcf/gct/issues])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])
 AC_SUBST([AGE_VERSION], [2])

--- a/gsi/simple_ca/source/grid-ca-create.1
+++ b/gsi/simple_ca/source/grid-ca-create.1
@@ -2,12 +2,12 @@
 .\"     Title: grid-ca-create
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 03/31/2018
+.\"      Date: 06/03/2020
 .\"    Manual: Grid Community Toolkit Manual
 .\"    Source: Grid Community Toolkit 6
 .\"  Language: English
 .\"
-.TH "GRID\-CA\-CREATE" "1" "03/31/2018" "Grid Community Toolkit 6" "Grid Community Toolkit Manual"
+.TH "GRID\-CA\-CREATE" "1" "06/03/2020" "Grid Community Toolkit 6" "Grid Community Toolkit Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -128,18 +128,6 @@ to protect the CA\(cqs private key\&. This is useful for automating Simple CA, b
 Disable building a source tarball for distributing the CA\(cqs public information to other machines\&. The source tarball can be created later by using the
 \fBgrid\-ca\-package\fR
 command\&.
-.RE
-.PP
-\fB\-g\fR
-.RS 4
-Create a binary GPT package containing the new CA\(cqs public information\&. The package will be created in the current working directory\&. This package can be deployed by with the
-\fBgpt\-install\fR
-tool\&.
-.RE
-.PP
-\fB\-b\fR
-.RS 4
-Create a binary GPT package containing the new CA\(cqs public information that is backward\-compatible with GPT 3\&.2\&. Packages created in this manner will work with Globus Toolkit 2\&.0\&.0\-5\&.0\&.x\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/gsi/simple_ca/source/grid-ca-create.in
+++ b/gsi/simple_ca/source/grid-ca-create.in
@@ -736,10 +736,6 @@ EOF
     printhelp "-nobuild" "Don't create a package for distributing
             configuration files for this CA. These can be created later by
             using the grid-ca-package utility [unset]"
-    printhelp "-g" "Create a GPT binary package containing the CA and
-            configuration files [unset]"
-    printhelp "-b" "Create a GPT binary package containing the CA and
-            configuration files compatible with GPT 3.2 and GT 4 and 5 [unset]"
     printhelp "-openssl-help" "Show help text for openssl"
     printhelp "[OPENSSL-OPTIONS]" "Specify additional options to pass to the 
             openssl command.  Use with caution, some options will conflict 
@@ -754,15 +750,6 @@ readCommandLine () {
       -\?|-h|-help|-usage|--help|--usage)
          long_usage
          exit 0
-         ;;
-     -g)
-         gpt_package=1
-         shift
-         ;;
-     -b)
-         gpt_package=1
-         backward_compatible=1
-         shift
          ;;
      -bits|--bits)
         shift
@@ -920,7 +907,7 @@ fi
 cahash="$("$openssl" x509 -in "$(construct_path ${_cadir}/cacert.pem)" -noout -hash)"
 
 if [ -z "$nobuild" ]; then
-    grid-ca-package ${backward_compatible:+-b} ${gpt_package:+-g} -cadir "${GRID_CA_DIR}"
+    grid-ca-package -cadir "${GRID_CA_DIR}"
 fi
 
 exit 0

--- a/gsi/simple_ca/source/grid-ca-create.txt
+++ b/gsi/simple_ca/source/grid-ca-create.txt
@@ -96,16 +96,6 @@ command when creating the self-signed certificate.
     information to other machines. The source tarball can be created later by
     using the *grid-ca-package* command.
 
-*-g*::
-    Create a binary GPT package containing the new CA's public information. The
-    package will be created in the current working directory. This package can
-    be deployed by with the *gpt-install* tool.
-
-*-b*::
-    Create a binary GPT package containing the new CA's public information that
-    is backward-compatible with GPT 3.2. Packages created in this manner will
-    work with Globus Toolkit 2.0.0-5.0.x.
-
 [[grid-ca-create-EXAMPLES]]
 EXAMPLES
 --------

--- a/gsi/simple_ca/source/grid-ca-package.1
+++ b/gsi/simple_ca/source/grid-ca-package.1
@@ -2,12 +2,12 @@
 .\"     Title: grid-ca-package
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 03/31/2018
+.\"      Date: 06/03/2020
 .\"    Manual: Grid Community Toolkit Manual
 .\"    Source: Grid Community Toolkit 6
 .\"  Language: English
 .\"
-.TH "GRID\-CA\-PACKAGE" "1" "03/31/2018" "Grid Community Toolkit 6" "Grid Community Toolkit Manual"
+.TH "GRID\-CA\-PACKAGE" "1" "06/03/2020" "Grid Community Toolkit 6" "Grid Community Toolkit Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -36,11 +36,9 @@ grid-ca-package \- Prepare a CA certificate, configuration, and policy for distr
 \fBgrid\-ca\-sign\fR [ \-help| \-h| \-usage| \-version| \-versions ]
 .SH "DESCRIPTION"
 .sp
-The \fBgrid\-ca\-sign\fR utility creates a tarball containing an RPM spec file and the files needed to use a CA with grid tools\&. It optionally will also create a GPT package for distributing a CA\&.
+The \fBgrid\-ca\-sign\fR utility creates a tarball containing an RPM spec file and the files needed to use a CA with grid tools\&.
 .sp
 By default, the \fBgrid\-ca\-sign\fR utility displays a list of installed grid CA and prompts for which CA to package\&. It then creates a tarball containing the CA certificate, signing policy, CA configuration files, and an spec script to generate a binary RPM package containing the CA\&. If the CA hash is known prior to running \fBgrid\-ca\-sign\fR, it may provided as an argument to the \fI\-ca\fR parameter to avoid prompting\&.
-.sp
-In addition to generating a spec script and tarball, \fBgrid\-ca\-sign\fR creates a GPT package if either the \fI\-g\fR or \fI\-b\fR options are used on the command\-line\&. These packages may be used to distribute a CA and configuration to systems which do not support RPM packages\&.
 .sp
 The \fBgrid\-ca\-sign\fR utility writes the package tarballs to the current working directory\&.
 .SH "OPTIONS"
@@ -67,20 +65,6 @@ Use the CA whose name matches the hash string
 \fICA\fR\&. When invoked with this option,
 \fBgrid\-ca\-sign\fR
 runs non\-interactively\&.
-.RE
-.PP
-\fB\-g\fR
-.RS 4
-Create a GPT binary package in addition to the RPM script tarball\&. This package may be installed on other systems using the
-\fBgpt\-install\fR
-program\&.
-.RE
-.PP
-\fB\-b\fR
-.RS 4
-Create a GPT binary package with GPT metadata located in the path expected by GPT 3\&.2 (used in Globus 2\&.0\&.0\-5\&.0\&.x) instead of overrides the
-\fI\-g\fR
-command\-line option\&.
 .RE
 .PP
 \fB\-r\fR

--- a/gsi/simple_ca/source/grid-ca-package.in
+++ b/gsi/simple_ca/source/grid-ca-package.in
@@ -61,7 +61,7 @@ ca_list() {
 
             for cert in ${cert_hashes}; do
                 if test -r "${cert}" ; then 
-                    TEMP_SUBJECT="$("$openssl" x509 -in ${cert} -noout -subject -nameopt rfc2253,-dn_rev | sed -e 's|^subject= *|/|' -e 's|,|/|g')"
+                    TEMP_SUBJECT=`"$openssl" x509 -in ${cert} -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
                     TEMP_HASH="${cert##*/}"
                     TEMP_HASH="${TEMP_HASH%.0}"
 
@@ -118,7 +118,7 @@ create_source_package_tarball()
     _cadir="${2}"
     _casubject="${3}"
     _simpleca="${4}"
-    _cahash="$("$openssl" x509 -hash -noout -in "${_capath}")"
+    _cahash=`"$openssl" x509 -hash -noout -in "${_capath}"`
 
     _certdir="share/certificates"
     _srcdir="globus-simple-ca-${_cahash}"
@@ -415,7 +415,7 @@ create_binary_gpt_package()
     _cadir="${2}"
     _casubject="${3}"
     _simpleca="${4}"
-    _cahash="$("$openssl" x509 -hash -noout -in "${_capath}")"
+    _cahash=`"$openssl" x509 -hash -noout -in "${_capath}"`
     _certdir="share/certificates"
     _binary_gpt_package="globus_simple_ca_${_cahash}-1.0-noflavor_data.tar.gz"
     if [ "${backward_compatible}" = 1 ]; then
@@ -696,7 +696,7 @@ fi
 if [ -n "$cadir" ]; then
     CA_CERT_DIR="$cadir"
     CA_CERT="$CA_CERT_DIR/cacert.pem"
-    CA_SUBJECT="$("$openssl" x509 -in "${CA_CERT}" -noout -subject -nameopt rfc2253,-dn_rev | sed -e 's|^subject= *|/|' -e 's|,|/|g')"
+    CA_SUBJECT=`"$openssl" x509 -in "${CA_CERT}" -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
     simpleca=1
 else
     found_ca=0
@@ -738,13 +738,13 @@ else
             echo 
             exit 1
         fi
-        CA_SUBJECT="$("$openssl" x509 -in ${CA_CERT} -noout -subject -nameopt rfc2253,-dn_rev | sed -e 's|^subject= *|/|' -e 's|,|/|g')"
+        CA_SUBJECT=`"$openssl" x509 -in "${CA_CERT}" -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
     fi
 fi
 
 if [ "$create_rpm_tarball" -eq 1 ]; then
     create_source_package_tarball "$CA_CERT" "$CA_CERT_DIR" "$CA_SUBJECT" "${simpleca}"
-    ca_cert_hash="$("$openssl" x509 -hash -noout -in "${CA_CERT}")"
+    ca_cert_hash=`"$openssl" x509 -hash -noout -in "${CA_CERT}"`
     source_package_tarball="globus_simple_ca_${ca_cert_hash}.tar.gz"
     if [ "$create_rpm_binary" -eq 1 ]; then
         create_rpm_binary_package "$(pwd)/${source_package_tarball}" "${ca_cert_hash}"

--- a/gsi/simple_ca/source/grid-ca-package.in
+++ b/gsi/simple_ca/source/grid-ca-package.in
@@ -61,7 +61,7 @@ ca_list() {
 
             for cert in ${cert_hashes}; do
                 if test -r "${cert}" ; then 
-                    TEMP_SUBJECT=`"$openssl" x509 -in ${cert} -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
+                    TEMP_SUBJECT=`"$openssl" x509 -in ${cert} -noout -subject -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n'`
                     TEMP_HASH="${cert##*/}"
                     TEMP_HASH="${TEMP_HASH%.0}"
 
@@ -576,7 +576,7 @@ fi
 if [ -n "$cadir" ]; then
     CA_CERT_DIR="$cadir"
     CA_CERT="$CA_CERT_DIR/cacert.pem"
-    CA_SUBJECT=`"$openssl" x509 -in "${CA_CERT}" -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
+    CA_SUBJECT=`"$openssl" x509 -in "${CA_CERT}" -noout -subject -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n'`
     simpleca=1
 else
     found_ca=0
@@ -618,7 +618,7 @@ else
             echo 
             exit 1
         fi
-        CA_SUBJECT=`"$openssl" x509 -in "${CA_CERT}" -noout -subject -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n'`
+        CA_SUBJECT=`"$openssl" x509 -in "${CA_CERT}" -noout -subject -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n'`
     fi
 fi
 

--- a/gsi/simple_ca/source/grid-ca-package.in
+++ b/gsi/simple_ca/source/grid-ca-package.in
@@ -408,116 +408,8 @@ create_debian_binary_package()
 
     rm -rf "$_pkgdir"
 }
-create_binary_gpt_package()
-{
-    _tmpdir="${TMPDIR:-/tmp}"
-    _capath="${1}"
-    _cadir="${2}"
-    _casubject="${3}"
-    _simpleca="${4}"
-    _cahash=`"$openssl" x509 -hash -noout -in "${_capath}"`
-    _certdir="share/certificates"
-    _binary_gpt_package="globus_simple_ca_${_cahash}-1.0-noflavor_data.tar.gz"
-    if [ "${backward_compatible}" = 1 ]; then
-        _gptdir="etc/gpt/packages/globus_simple_ca_${_cahash}"
-    else
-        _gptdir="share/globus/packages/globus_simple_ca_${_cahash}"
-    fi
-    _filelist="${_gptdir}/noflavor_data.filelist"
-    _metadata="${_gptdir}/pkg_data_noflavor_data.gpt"
-    _pkgdir=""
-
-    printf "Creating binary GPT package... "
-
-    while [ "$_pkgdir" = "" ]; do
-        mkdir -m 0755 "${_pkgdir:=${_tmpdir}/globus_simple_ca.$("$openssl" rand -hex 16)}"
-        rc=$?
-
-        if [ $rc != 0 ]; then
-            _pkgdir=""
-        fi
-    done
-
-    cd "${_pkgdir}"
-
-    mkdir -p "${_certdir}"
-    mkdir -p "${_gptdir}"
-
-    exec 3>&1
-    exec 1> "${_filelist}"
-
-    cp "${_capath}" "${_certdir}/${_cahash}.0"
-    echo "${_certdir}/${_cahash}.0"
-
-    if [ "${_simpleca}" -eq 0 ]; then
-        cp "${_cadir}/${_cahash}.signing_policy" "${_certdir}/"
-        echo "${_certdir}/${_cahash}.signing_policy"
-        if [ -r "${_cadir}/grid-security.conf.${_cahash}" ]; then
-            cp "${_cadir}/grid-security.conf.${_cahash}" "${_certdir}/"
-            echo "${_certdir}/grid-security.conf.${_cahash}"
-        fi
-
-        if [ -r "${_cadir}/globus-user-ssl.conf.${_cahash}" ]; then
-            cp "${_cadir}/globus-user-ssl.conf.${_cahash}" "${_certdir}/"
-            echo "${_certdir}/globus-user-ssl.conf.${_cahash}"
-        fi
-        if [ -r "${_cadir}/globus-host-ssl.conf.${_cahash}" ]; then
-            cp "${_cadir}/globus-host-ssl.conf.${_cahash}" "${_certdir}/"
-            echo "${_certdir}/globus-host-ssl.conf.${_cahash}"
-        fi
-    else
-        cp "${_cadir}/signing-policy" "${_certdir}/${_cahash}.signing_policy"
-        echo "${_certdir}/${_cahash}.signing_policy"
-
-        if [ -r "${_cadir}/grid-security.conf" ]; then
-            cp "${_cadir}/grid-security.conf" \
-                    "${_certdir}/grid-security.conf.${_cahash}"
-            echo "${_certdir}/grid-security.conf.${_cahash}"
-        fi
-
-        if [ -r "${_cadir}/globus-user-ssl.conf" ]; then
-            cp "${_cadir}/globus-user-ssl.conf" \
-                    "${_certdir}/globus-user-ssl.conf.${_cahash}"
-            echo "${_certdir}/globus-user-ssl.conf.${_cahash}"
-        fi
-        if [ -r "${_cadir}/globus-host-ssl.conf" ]; then
-            cp "${_cadir}/globus-host-ssl.conf" \
-                    "${_certdir}/globus-host-ssl.conf.${_cahash}"
-            echo "${_certdir}/globus-host-ssl.conf.${_cahash}"
-        fi
-    fi
-
-    echo "${_filelist}"
-    echo "${_metadata}"
-
-    cat <<-EOF 1> "${_metadata}"
-<?xml version="1.0"?>
-<!DOCTYPE gpt_package_metadata SYSTEM "globus_package.dtd">
-<gpt_package_metadata Format_Version="0.02" Name="globus_simple_ca_${_cahash}" >
-<Aging_Version Age="0" Major="0" Minor="6" />
-<Description >Simple CA Package for ${_casubject}</Description>
-<Functional_Group >Security</Functional_Group>
-<Version_Stability Release="Experimental" />
-<PackagingTool ToolName="GPT" ToolVersion="3.3" />
-<data_pkg >
-<Flavor ColocateLibraries="no" >noflavor</Flavor>
-</data_pkg>
-</gpt_package_metadata>
-EOF
-    
-    exec 1>&3
-    exec 3>&-
-
-    tar cf - $(cat "${_filelist}") | gzip > "${OLDPWD}/${_binary_gpt_package}"
-
-    cd "${OLDPWD}"
-    rm -rf "${_pkgdir}"
-    echo "done"
-    printf "\t${_binary_gpt_package}\n"
-}
 
 create_rpm_tarball=1
-create_gpt_package=0
 create_rpm_binary=0
 create_debian_binary=0
 
@@ -539,21 +431,12 @@ readCommandLine () {
                 cadir="$2"
                 shift 2
                 ;;
-            -g)
-                create_gpt_package=1
-                shift;
-                ;;
             -r)
                 create_rpm_binary=1
                 shift;
                 ;;
             -d)
                 create_debian_binary=1
-                shift;
-                ;;
-            -b)
-                backward_compatible=1
-                create_gpt_package=1
                 shift;
                 ;;
              -version|--version)
@@ -633,9 +516,6 @@ long_usage () {
     printhelp "-versions" "Print detailed package version for $PACKAGE"
     printhelp "-ca HASH" "Create packages for the CA with HASH as its subject
             hash [prompt for value]"
-    printhelp "-g" "Create a GPT binary package [unset]"
-    printhelp "-b" "Create a GPT binary package compatible with GPT 3.2 to be
-            used with GT 2.0.x - 5.0.x [unset]"
     printhelp "-r" "Create an RPM binary package [unset]"
     printhelp "-d" "Create an debian binary package [unset]"
 }
@@ -752,9 +632,6 @@ if [ "$create_rpm_tarball" -eq 1 ]; then
     if [ "$create_debian_binary" -eq 1 ]; then
         create_debian_binary_package "$(pwd)/${source_package_tarball}" "${ca_cert_hash}"
     fi
-fi
-if [ "$create_gpt_package" -eq 1 ]; then
-    create_binary_gpt_package "$CA_CERT" "$CA_CERT_DIR" "$CA_SUBJECT" "${simpleca}"
 fi
 
 exit 0

--- a/gsi/simple_ca/source/grid-ca-package.txt
+++ b/gsi/simple_ca/source/grid-ca-package.txt
@@ -21,8 +21,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 The *grid-ca-sign* utility creates a tarball containing an RPM spec file and
-the files needed to use a CA with grid tools. It optionally will also
-create a GPT package for distributing a CA.
+the files needed to use a CA with grid tools.
 
 By default, the *grid-ca-sign* utility displays a list of installed grid CA and
 prompts for which CA to package. It then creates a tarball containing the CA
@@ -30,11 +29,6 @@ certificate, signing policy, CA configuration files, and an spec script to
 generate a binary RPM package containing the CA. If the CA hash is known prior
 to running *grid-ca-sign*, it may provided as an argument to the
 '-ca' parameter to avoid prompting.
-
-In addition to generating a spec script and tarball, *grid-ca-sign* creates a
-GPT package if either the '-g' or '-b' options
-are used on the command-line. These packages may be used to distribute a CA and
-configuration to systems which do not support RPM packages.
 
 The *grid-ca-sign* utility writes the package tarballs to the current working
 directory.
@@ -53,15 +47,6 @@ The full set of command-line options to *grid-ca-sign* follows:
 *-ca 'CA'*::
     Use the CA whose name matches the hash string 'CA'. When invoked with this
     option, *grid-ca-sign* runs non-interactively.
-*-g*::
-    Create a GPT binary package in addition to the RPM script tarball. This
-    package may be installed on other systems using the
-    *gpt-install* program.
-*-b*::
-    Create a GPT binary package with GPT metadata located in the path expected
-    by GPT 3.2 (used in Globus 2.0.0-5.0.x) instead of
-    +${datadir}/globus/packages+ as used in Globus 5.2.x. This option
-    overrides the '-g' command-line option.
 *-r*::
     Create a binary RPM package for the CA. This option currently only works on
     RPM-based distributions.

--- a/gsi/simple_ca/source/grid-ca-sign.in
+++ b/gsi/simple_ca/source/grid-ca-sign.in
@@ -262,7 +262,7 @@ if test ${openssl_result} != 0; then
         subj_tmp_output=/tmp/tmp_output.$$
         "${openssl_cmd}" req -noout -in $(construct_path ${INPUT_REQ_FILE}) \
                            -subject -nameopt sep_multiline | \
-                           sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n' \
+                           sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n' \
                            > ${subj_tmp_output} 2>&1
         res=$?
         if test $res != 0; then
@@ -280,7 +280,7 @@ if test ${openssl_result} != 0; then
             subj_tmp_output=/tmp/tmp_output.$$
             "${openssl_cmd}" x509 -noout -in $(construct_path ${p}) \
                                -subject -nameopt sep_multiline | \
-                               sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n' \
+                               sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n' \
                                > ${subj_tmp_output} 2>&1
             res=$?
             if test $res != 0; then

--- a/gsi/simple_ca/source/grid-ca-sign.in
+++ b/gsi/simple_ca/source/grid-ca-sign.in
@@ -261,7 +261,8 @@ if test ${openssl_result} != 0; then
 
         subj_tmp_output=/tmp/tmp_output.$$
         "${openssl_cmd}" req -noout -in $(construct_path ${INPUT_REQ_FILE}) \
-                           -subject -nameopt rfc2253,-dn_rev \
+                           -subject -nameopt sep_multiline | \
+                           sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n' \
                            > ${subj_tmp_output} 2>&1
         res=$?
         if test $res != 0; then
@@ -277,8 +278,9 @@ if test ${openssl_result} != 0; then
         # find signed cert
         for p in ${GRID_CA_DIR}/newcerts/*.pem; do
             subj_tmp_output=/tmp/tmp_output.$$
-            "${openssl_cmd}" x509 -noout -subject -in $(construct_path ${p}) \
-                               -nameopt rfc2253,-dn_rev \
+            "${openssl_cmd}" x509 -noout -in $(construct_path ${p}) \
+                               -subject -nameopt sep_multiline | \
+                               sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n' \
                                > ${subj_tmp_output} 2>&1
             res=$?
             if test $res != 0; then

--- a/io/compat/configure.ac
+++ b/io/compat/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_io],[12.2],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_io],[12.3],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/io/compat/test/globus-io-authorization-test.pl
+++ b/io/compat/test/globus-io-authorization-test.pl
@@ -55,9 +55,7 @@ sub basic_func
 }
 
 plan tests => 5;
-chomp(my $identity = `openssl x509 -subject -in \${X509_USER_CERT-\$HOME/.globus/usercert.pem} -noout -nameopt rfc2253,-dn_rev`);
-$identity =~ s/^subject= */\//;
-$identity =~ s/,/\//g;
+my $identity = `openssl x509 -subject -in \${X509_USER_CERT-\$HOME/.globus/usercert.pem} -noout -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
 print "    Using test identity $identity\n";
 
 basic_func('self', 0, "$test_prog-self");

--- a/io/compat/test/globus-io-authorization-test.pl
+++ b/io/compat/test/globus-io-authorization-test.pl
@@ -55,7 +55,7 @@ sub basic_func
 }
 
 plan tests => 5;
-my $identity = `openssl x509 -subject -in \${X509_USER_CERT-\$HOME/.globus/usercert.pem} -noout -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
+my $identity = `openssl x509 -subject -in \${X509_USER_CERT-\$HOME/.globus/usercert.pem} -noout -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\\s*!/!' | tr -d '\\n'`;
 print "    Using test identity $identity\n";
 
 basic_func('self', 0, "$test_prog-self");

--- a/io/compat/test/globus-io-tcp-test.pl
+++ b/io/compat/test/globus-io-tcp-test.pl
@@ -41,7 +41,7 @@ if (exists $ENV{VALGRIND})
     }
 }
 
-my $identity = `openssl x509 -subject -in \${X509_USER_CERT-\$HOME/.globus/usercert.pem} -noout -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
+my $identity = `openssl x509 -subject -in \${X509_USER_CERT-\$HOME/.globus/usercert.pem} -noout -nameopt sep_multiline | sed -e '/^subject=/d' -e 's!^\\s*!/!' | tr -d '\\n'`;
 diag("Using test identity $identity");
 
 sub basic_func

--- a/io/compat/test/globus-io-tcp-test.pl
+++ b/io/compat/test/globus-io-tcp-test.pl
@@ -41,9 +41,7 @@ if (exists $ENV{VALGRIND})
     }
 }
 
-chomp(my $identity = `openssl x509 -subject -in \${X509_USER_CERT-\$HOME/.globus/usercert.pem} -noout -nameopt rfc2253,-dn_rev`);
-$identity =~ s/^subject= */\//;
-$identity =~ s/,/\//g;
+my $identity = `openssl x509 -subject -in \${X509_USER_CERT-\$HOME/.globus/usercert.pem} -noout -nameopt sep_multiline | sed -e /^subject=/d -e 's!^\\s*!/!' | tr -d '\\n'`;
 diag("Using test identity $identity");
 
 sub basic_func

--- a/packaging/debian/globus-ftp-client/debian/changelog.in
+++ b/packaging/debian/globus-ftp-client/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-ftp-client (9.5-1+gct.@distro@) @distro@; urgency=medium
+
+  * Use -nameopt sep_multiline to derive certificate subject string
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 03 Jun 2020 19:23:45 +0200
+
 globus-ftp-client (9.4-1+gct.@distro@) @distro@; urgency=medium
 
   * Remove some unused test scripts

--- a/packaging/debian/globus-ftp-control/debian/changelog.in
+++ b/packaging/debian/globus-ftp-control/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-ftp-control (9.6-1+gct.@distro@) @distro@; urgency=medium
+
+  * Use -nameopt sep_multiline to derive certificate subject string
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 03 Jun 2020 19:30:23 +0200
+
 globus-ftp-control (9.5-1+gct.@distro@) @distro@; urgency=medium
 
   * Make makefiles exit sooner on errors

--- a/packaging/debian/globus-gass-copy/debian/changelog.in
+++ b/packaging/debian/globus-gass-copy/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gass-copy (10.7-1+gct.@distro@) @distro@; urgency=medium
+
+  * Use -nameopt sep_multiline to derive certificate subject string
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 03 Jun 2020 19:20:22 +0200
+
 globus-gass-copy (10.6-1+gct.@distro@) @distro@; urgency=medium
 
   * Make makefiles exit sooner on errors

--- a/packaging/debian/globus-gsi-cert-utils/debian/changelog.in
+++ b/packaging/debian/globus-gsi-cert-utils/debian/changelog.in
@@ -1,14 +1,20 @@
+globus-gsi-cert-utils (10.7-1+gct.@distro@) @distro@; urgency=medium
+
+  * Use -nameopt sep_multiline to derive certificate subject string
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 03 Jun 2020 19:35:07 +0200
+
 globus-gsi-cert-utils (10.6-1+gct.@distro@) @distro@; urgency=medium
 
   * Fix format for grid-cert-info -issuer
 
- -- Mattias Ellert <ellert@ellert.physics.uu.se>  Mon, 01 Jun 2020 21:00:36 +0200
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Mon, 01 Jun 2020 21:00:36 +0200
 
 globus-gsi-cert-utils (10.5-1+gct.@distro@) @distro@; urgency=medium
 
   * Remove old replace-version.xsl file
 
- -- Mattias Ellert <ellert@ellert.physics.uu.se>  Tue, 17 Mar 2020 06:15:48 +0100
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Tue, 17 Mar 2020 06:15:48 +0100
 
 globus-gsi-cert-utils (10.4-1+gct.@distro@) @distro@; urgency=medium
 

--- a/packaging/debian/globus-io/debian/changelog.in
+++ b/packaging/debian/globus-io/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-io (12.3-1+gct.@distro@) @distro@; urgency=medium
+
+  * Use -nameopt sep_multiline to derive certificate subject string
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 03 Jun 2020 19:53:17 +0200
+
 globus-io (12.2-1+gct.@distro@) @distro@; urgency=medium
 
   * Fix test race condition

--- a/packaging/debian/globus-simple-ca/debian/changelog.in
+++ b/packaging/debian/globus-simple-ca/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-simple-ca (5.2-1+gct.@distro@) @distro@; urgency=medium
+
+  * Use -nameopt sep_multiline to derive certificate subject string
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 03 Jun 2020 19:48:46 +0200
+
 globus-simple-ca (5.1-2+gct.@distro@) @distro@; urgency=medium
 
   * Check that hostname command succeeds in post install script

--- a/packaging/debian/globus-simple-ca/debian/changelog.in
+++ b/packaging/debian/globus-simple-ca/debian/changelog.in
@@ -1,6 +1,7 @@
 globus-simple-ca (5.2-1+gct.@distro@) @distro@; urgency=medium
 
   * Use -nameopt sep_multiline to derive certificate subject string
+  * Drop support for generating GPT package
 
  -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 03 Jun 2020 19:48:46 +0200
 

--- a/packaging/debian/globus-simple-ca/debian/globus-simple-ca.postrm
+++ b/packaging/debian/globus-simple-ca/debian/globus-simple-ca.postrm
@@ -8,14 +8,14 @@ gsdir=/etc/grid-security
 if [ "$1" = purge ]; then
     if [ -f $simplecadir/cacert.pem ]; then
         subj=$(openssl x509 -subject -noout -in $simplecadir/cacert.pem -nameopt sep_multiline | \
-            sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n')
+            sed -e '/^subject=/d' -e 's!^\s*!/!' | tr -d '\n')
         hash=$(openssl x509 -hash -noout -in $simplecadir/cacert.pem)
 
         # Remove host cert if signed by this CA
         hostcert="$gsdir/hostcert.pem"
         if [ -f "$hostcert" ]; then
             hostcert_issuer=$(openssl x509 -issuer -noout -in "$hostcert" -nameopt sep_multiline | \
-                sed -e /^issuer=/d -e 's!^\s*!/!' | tr -d '\n')
+                sed -e '/^issuer=/d' -e 's!^\s*!/!' | tr -d '\n')
             if [ "$hostcert_issuer" = "$subj" ]; then
                 rm -f "$gsdir/hostcert.pem"
                 rm -f "$gsdir/hostcert_request.pem"

--- a/packaging/debian/globus-simple-ca/debian/globus-simple-ca.postrm
+++ b/packaging/debian/globus-simple-ca/debian/globus-simple-ca.postrm
@@ -7,15 +7,15 @@ gsdir=/etc/grid-security
 # deal with the hostcert, but this makes it symmetric with the postinst
 if [ "$1" = purge ]; then
     if [ -f $simplecadir/cacert.pem ]; then
-        subj="$(openssl x509 -subject -noout -in $simplecadir/cacert.pem -nameopt rfc2253,-dn_rev | \
-            sed -e 's|^subject= *|/|' -e 's|,|/|g')"
-        hash="$(openssl x509 -hash -noout -in $simplecadir/cacert.pem)"
+        subj=$(openssl x509 -subject -noout -in $simplecadir/cacert.pem -nameopt sep_multiline | \
+            sed -e /^subject=/d -e 's!^\s*!/!' | tr -d '\n')
+        hash=$(openssl x509 -hash -noout -in $simplecadir/cacert.pem)
 
         # Remove host cert if signed by this CA
         hostcert="$gsdir/hostcert.pem"
         if [ -f "$hostcert" ]; then
-            hostcert_issuer="$(openssl x509 -issuer -noout -in "$hostcert" -nameopt rfc2253,-dn_rev | \
-                sed -e 's|^issuer= *|/|' -e 's|,|/|g')"
+            hostcert_issuer=$(openssl x509 -issuer -noout -in "$hostcert" -nameopt sep_multiline | \
+                sed -e /^issuer=/d -e 's!^\s*!/!' | tr -d '\n')
             if [ "$hostcert_issuer" = "$subj" ]; then
                 rm -f "$gsdir/hostcert.pem"
                 rm -f "$gsdir/hostcert_request.pem"

--- a/packaging/debian/globus-xio-gridftp-driver/debian/changelog.in
+++ b/packaging/debian/globus-xio-gridftp-driver/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-xio-gridftp-driver (3.4-1+gct.@distro@) @distro@; urgency=medium
+
+  * Use -nameopt sep_multiline to derive certificate subject string
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 03 Jun 2020 19:32:33 +0200
+
 globus-xio-gridftp-driver (3.3-1+gct.@distro@) @distro@; urgency=medium
 
   * Make makefiles exit sooner on errors

--- a/packaging/fedora/globus-ftp-client.spec
+++ b/packaging/fedora/globus-ftp-client.spec
@@ -3,8 +3,8 @@
 Name:		globus-ftp-client
 %global soname 2
 %global _name %(echo %{name} | tr - _)
-Version:	9.4
-Release:	2%{?dist}
+Version:	9.5
+Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GridFTP Client Library
 
 Group:		System Environment/Libraries
@@ -169,6 +169,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Wed Jun 03 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.5-1
+- Use -nameopt sep_multiline to derive certificate subject string
+
 * Thu Mar 12 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.4-2
 - Add BuildRequires perl-interpreter
 - Add additional perl dependencies for tests

--- a/packaging/fedora/globus-ftp-control.spec
+++ b/packaging/fedora/globus-ftp-control.spec
@@ -3,7 +3,7 @@
 Name:		globus-ftp-control
 %global soname 1
 %global _name %(echo %{name} | tr - _)
-Version:	9.5
+Version:	9.6
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GridFTP Control Library
 
@@ -144,6 +144,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Wed Jun 03 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.6-1
+- Use -nameopt sep_multiline to derive certificate subject string
+
 * Tue Mar 10 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.5-1
 - Make makefiles exit sooner on errors
 

--- a/packaging/fedora/globus-gass-copy.spec
+++ b/packaging/fedora/globus-gass-copy.spec
@@ -3,8 +3,8 @@
 Name:		globus-gass-copy
 %global soname 2
 %global _name %(echo %{name} | tr - _)
-Version:	10.6
-Release:	2%{?dist}
+Version:	10.7
+Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gass Copy
 
 Group:		System Environment/Libraries
@@ -183,6 +183,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Wed Jun 03 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.7-1
+- Use -nameopt sep_multiline to derive certificate subject string
+
 * Tue Mar 10 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.6-2
 - Add BuildRequires perl-interpreter
 - Add additional perl dependencies for tests

--- a/packaging/fedora/globus-gsi-cert-utils.spec
+++ b/packaging/fedora/globus-gsi-cert-utils.spec
@@ -3,7 +3,7 @@
 Name:		globus-gsi-cert-utils
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	10.6
+Version:	10.7
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Cert Utils Library
 
@@ -180,6 +180,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Wed Jun 03 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.7-1
+- Use -nameopt sep_multiline to derive certificate subject string
+
 * Mon Jun 01 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.6-1
 - Fix format for grid-cert-info -issuer
 

--- a/packaging/fedora/globus-io.spec
+++ b/packaging/fedora/globus-io.spec
@@ -3,8 +3,8 @@
 Name:		globus-io
 %global soname 3
 %global _name %(echo %{name} | tr - _)
-Version:	12.2
-Release:	2%{?dist}
+Version:	12.3
+Release:	1%{?dist}
 Summary:	Grid Community Toolkit - uniform I/O interface
 
 Group:		System Environment/Libraries
@@ -121,6 +121,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Wed Jun 03 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 12.3-1
+- Use -nameopt sep_multiline to derive certificate subject string
+
 * Tue Mar 10 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 12.2-2
 - Add BuildRequires perl-interpreter
 - Add additional perl dependencies for tests

--- a/packaging/fedora/globus-simple-ca.spec
+++ b/packaging/fedora/globus-simple-ca.spec
@@ -2,8 +2,8 @@
 
 Name:		globus-simple-ca
 %global _name %(echo %{name} | tr - _)
-Version:	5.1
-Release:	3%{?dist}
+Version:	5.2
+Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Simple CA Utility
 
 Group:		Applications/Internet
@@ -116,6 +116,9 @@ fi
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Wed Jun 03 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 5.2-1
+- Use -nameopt sep_multiline to derive certificate subject string
+
 * Tue Mar 10 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 5.1-3
 - Add BuildRequires perl-interpreter
 - Add additional perl dependencies for tests

--- a/packaging/fedora/globus-simple-ca.spec
+++ b/packaging/fedora/globus-simple-ca.spec
@@ -118,6 +118,7 @@ fi
 %changelog
 * Wed Jun 03 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 5.2-1
 - Use -nameopt sep_multiline to derive certificate subject string
+- Drop support for generating GPT package
 
 * Tue Mar 10 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 5.1-3
 - Add BuildRequires perl-interpreter

--- a/packaging/fedora/globus-xio-gridftp-driver.spec
+++ b/packaging/fedora/globus-xio-gridftp-driver.spec
@@ -2,8 +2,8 @@
 
 Name:		globus-xio-gridftp-driver
 %global _name %(echo %{name} | tr - _)
-Version:	3.3
-Release:	2%{?dist}
+Version:	3.4
+Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus XIO GridFTP Driver
 
 Group:		System Environment/Libraries
@@ -152,6 +152,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Wed Jun 03 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 3.4-1
+- Use -nameopt sep_multiline to derive certificate subject string
+
 * Tue Mar 10 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 3.3-2
 - Add BuildRequires perl-interpreter
 - Add additional perl dependencies for tests


### PR DESCRIPTION
- Use -nameopt sep_multiline to derive certificate subject string
- Drop support for generating GPT package (simple CA)
