### PR TITLE
Check for LTO use in CFLAGS instead of LDFLAGS

### DIFF
--- a/common/source/configure.ac
+++ b/common/source/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.60])
-AC_INIT([globus_common], [18.8], [https://github.com/gridcf/gct/issues])
+AC_INIT([globus_common], [18.9], [https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])
@@ -148,7 +148,7 @@ if test "$use_symbol_labels" = yes; then
     AC_DEFINE(USE_SYMBOL_LABELS, 1, [Use backward-compatibility symbol labels])
 fi
 
-AM_CONDITIONAL(USES_LTO, [echo $LDFLAGS | grep -q -- -flto])
+AM_CONDITIONAL(USES_LTO, [echo $CFLAGS | grep -q -- -flto])
 
 AC_PATH_PROGS([A2X], [a2x a2x.py])
 AM_CONDITIONAL(BUILD_MANPAGES, [test x"$A2X" != x])

--- a/packaging/debian/globus-common/debian/changelog.in
+++ b/packaging/debian/globus-common/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-common (18.9-1+gct.@distro@) @distro@; urgency=medium
+
+  * Check for LTO use in CFLAGS instead of LDFLAGS
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Thu, 16 Jul 2020 10:36:35 +0200
+
 globus-common (18.8-1+gct.@distro@) @distro@; urgency=medium
 
   * Remove unused doxygen filter

--- a/packaging/fedora/globus-common.spec
+++ b/packaging/fedora/globus-common.spec
@@ -3,8 +3,8 @@
 Name:		globus-common
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	18.8
-Release:	2%{?dist}
+Version:	18.9
+Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Common Library
 
 Group:		System Environment/Libraries
@@ -239,6 +239,9 @@ make %{?_smp_mflags} check VERBOSE=1 NO_EXTERNAL_NET=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Thu Jul 16 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 18.9-1
+- Check for LTO use in CFLAGS instead of LDFLAGS
+
 * Thu Mar 12 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 18.8-2
 - Add BuildRequires perl-interpreter
 


### PR DESCRIPTION
Fedora recently implemented LTO as default.
Fedora only adds the -flto flag to CFLAGS and not to both CFLAGS and LDFLAGS.
This update adapts the LTO detection for this.
