### PR TITLE
gridftp: Use example message from RFC 2428 for response to EPSV

### DIFF
--- a/gridftp/server-lib/src/configure.ac
+++ b/gridftp/server-lib/src/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gridftp_server_control],[9.0],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gridftp_server_control],[9.1],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gridftp/server-lib/src/globus_gridftp_server_control_commands.c
+++ b/gridftp/server-lib/src/globus_gridftp_server_control_commands.c
@@ -2075,7 +2075,7 @@ globus_l_gsc_cmd_pasv_cb(
             if(op->server_handle->epsv_ip)
             {
                 msg = globus_common_create_string(
-                    "%d Entering Passive Mode (|%d|%s|%d|)\r\n",
+                    "%d Entering Extended Passive Mode (|%d|%s|%d|)\r\n",
                         wrapper->reply_code,
                         *host == '[' ? 2 : 1,
                         h,
@@ -2084,7 +2084,7 @@ globus_l_gsc_cmd_pasv_cb(
             else
             {
                 msg = globus_common_create_string(
-                    "%d Entering Passive Mode (|||%d|)\r\n",
+                    "%d Entering Extended Passive Mode (|||%d|)\r\n",
                         wrapper->reply_code,                    
                         (int) port);
             }

--- a/packaging/debian/globus-gridftp-server-control/debian/changelog.in
+++ b/packaging/debian/globus-gridftp-server-control/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gridftp-server-control (9.1-1+gct.@distro@) @distro@; urgency=medium
+
+  * Use example message from RFC 2428 for response to EPSV
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 26 Aug 2020 16:34:32 +0200
+
 globus-gridftp-server-control (9.0-1+gct.@distro@) @distro@; urgency=medium
 
   * Fix problems between dual-stack (IPv4/IPv6) servers and IPv4-only clients

--- a/packaging/debian/globus-gridftp-server-control/debian/copyright
+++ b/packaging/debian/globus-gridftp-server-control/debian/copyright
@@ -5,12 +5,12 @@ Upstream-Contact: https://github.com/gridcf/gct/
 Files: *
 Copyright:
  1999-2018 University of Chicago
- 2018-2019 Grid Community Forum
+ 2018-2020 Grid Community Forum
 License: Apache-2.0
 
 Files: debian/*
 Copyright:
- 2008-2019 Mattias Ellert <mattias.ellert@physics.uu.se>
+ 2008-2020 Mattias Ellert <mattias.ellert@physics.uu.se>
  2010-2013 Initiative for Globus in Europe (IGE), http://www.ige-project.eu/
 License: Apache-2.0
 

--- a/packaging/fedora/globus-gridftp-server-control.spec
+++ b/packaging/fedora/globus-gridftp-server-control.spec
@@ -3,7 +3,7 @@
 Name:		globus-gridftp-server-control
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	9.0
+Version:	9.1
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GridFTP Server Library
 
@@ -112,6 +112,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.la
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Wed Aug 26 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.1-1
+- Use example message from RFC 2428 for response to EPSV
+
 * Thu Aug 08 2019 Frank Scheiner <scheiner@hlrs.de> - 9.0-1
 - Fix problems between dual-stack (IPv4/IPv6) servers and IPv4-only clients
 


### PR DESCRIPTION
Title says it all.

Not a big change, but from now on the Globus GridFTP server should use the exact example message for a response to `EPSV` from [RFC 2428](https://tools.ietf.org/html/rfc2428), although the difference to a response to `PASV` could be already seen from the differences in the actual data part of the response (e.g. `(1,2,3,4,195,80)` (in response to `PASV`) and `(|||50000|)` (in response to `EPSV`)).

The difference to RFC 2428 was noticed during testing UberFTP 2.9-Beta against a Globus GridFTP server 13.20. UberFTP 2.9-Beta uses `EPSV` and `EPRT` by default (both commands are compatible with IPv4 and IPv6 address families) instead of `PASV` and `PORT` .

@msalle, @ellert: Sorry, but I'm again unsure about what to change in addition (major, minor version of "globus-gridftp-server-control" and "globus-gridftp-server", packaging information, library version) as this is not a functionality change and I don't expect clients to behave differently due to the changed message. Could you please help me out? :-)