### PR TITLE
Add force option if the users do not exist in the machine (needed for e.g. EUDAT B2STAGE)

### DIFF
--- a/gsi/gss_assist/source/programs/grid-mapfile-add-entry.8
+++ b/gsi/gss_assist/source/programs/grid-mapfile-add-entry.8
@@ -2,12 +2,12 @@
 .\"     Title: grid-mapfile-add-entry
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 06/12/2020
+.\"      Date: 08/21/2020
 .\"    Manual: Grid Community Toolkit Manual
 .\"    Source: Grid Community Toolkit 6
 .\"  Language: English
 .\"
-.TH "GRID\-MAPFILE\-ADD\-" "8" "06/12/2020" "Grid Community Toolkit 6" "Grid Community Toolkit Manual"
+.TH "GRID\-MAPFILE\-ADD\-" "8" "08/21/2020" "Grid Community Toolkit 6" "Grid Community Toolkit Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -87,7 +87,7 @@ Modify the gridmap file named by
 instead of the default\&.
 .RE
 .PP
-*\-force
+\fB\-force\fR
 .RS 4
 Make modifications even if user does not exist (needed for B2STAGE)\&.
 .RE

--- a/gsi/gss_assist/source/programs/grid-mapfile-add-entry.8
+++ b/gsi/gss_assist/source/programs/grid-mapfile-add-entry.8
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: grid-mapfile-add-entry
 .\"    Author: [see the "AUTHOR" section]
-.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 03/31/2018
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 06/12/2020
 .\"    Manual: Grid Community Toolkit Manual
 .\"    Source: Grid Community Toolkit 6
 .\"  Language: English
 .\"
-.TH "GRID\-MAPFILE\-ADD\-" "8" "03/31/2018" "Grid Community Toolkit 6" "Grid Community Toolkit Manual"
+.TH "GRID\-MAPFILE\-ADD\-" "8" "06/12/2020" "Grid Community Toolkit 6" "Grid Community Toolkit Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -33,7 +33,7 @@ grid-mapfile-add-entry \- Add an entry to a gridmap file
 .sp
 \fBgrid\-mapfile\-add\-entry\fR [ \-h | \-help | \-usage | \-version | \-versions ]
 .sp
-\fBgrid\-mapfile\-add\-entry\fR \-dn \fIDISTINGUISHED\-NAME\fR \-ln \fILOCAL\-NAME\fR\&... [\-d | \-dryrun] [ \-f \fIMAPFILE\fR | \-mapfile \fIMAPFILE\fR ] [ \-n ] [ \-c ]
+\fBgrid\-mapfile\-add\-entry\fR \-dn \fIDISTINGUISHED\-NAME\fR \-ln \fILOCAL\-NAME\fR\&... [\-d | \-dryrun] [ \-f \fIMAPFILE\fR | \-mapfile \fIMAPFILE\fR ] [\-force] [ \-n ] [ \-c ]
 .SH "DESCRIPTION"
 .sp
 The \fBgrid\-mapfile\-add\-entry\fR program adds a new mapping from an X\&.509 distinguished name to a local POSIX user name to a gridmap file\&. Gridmap files are used as a simple authorization method for services such as GRAM5 or GridFTP\&.
@@ -72,7 +72,7 @@ The POSIX user name to map the distinguished name to\&. This name must be a vali
 \fILOCAL\-NAME\fR
 strings after the
 \fI\-ln\fR
-command\-line option\&. If any of the local names are invalid, no changes will be made to the gridmap file\&.
+command\-line option\&. If any of the local names are invalid, no changes will be made to the gridmap file (but see force option below)\&.
 .RE
 .PP
 \fB\-d, \-dryrun\fR
@@ -85,6 +85,11 @@ Verify local names and display diagnostics about what would be added to the grid
 Modify the gridmap file named by
 \fIMAPFILE\fR
 instead of the default\&.
+.RE
+.PP
+*\-force
+.RS 4
+Make modifications even if user does not exist (needed for B2STAGE)\&.
 .RE
 .PP
 \fB\-n\fR

--- a/gsi/gss_assist/source/programs/grid-mapfile-add-entry.in
+++ b/gsi/gss_assist/source/programs/grid-mapfile-add-entry.in
@@ -39,6 +39,7 @@ my $NEW_GRID_MAP_FILE;
 my $secconfdir="/etc/grid-security";
 my $GRID_MAP_FILE = $ENV{GRIDMAP} || "${secconfdir}/grid-mapfile";
 my $dryrun = 0;
+my $force = 0;
 
 my $short_usage="$PROGRAM_NAME -dn DN -ln LN [-help] [-d] [-f mapfile FILE]";
 
@@ -58,6 +59,7 @@ Options:
   -dryrun, -d             Shows what would be done but will not add the entry
   -mapfile FILE, -f FILE  Path of Grid map file to be used
 
+  -force                  Make modifications even if user does not exist (needed for B2STAGE)
 EOF
 }
 
@@ -88,7 +90,9 @@ GetOptions(
     "dn=s" => \$dn,
     "ln=s{1,}" => \@ln,
     "d|dryrun" => \$dryrun,
-    "f|mapfile=s" => \$GRID_MAP_FILE);
+    "f|mapfile=s" => \$GRID_MAP_FILE,
+    "force" => \$force);
+
 $lnstring = join(" ", @ln);
 if ($help)
 {
@@ -157,8 +161,10 @@ chmod 0400, $GRID_MAP_FILE
 print "Verifying that Local Name(s)=($lnstring) are legitimate local accounts.\n"
     if ($dryrun);
 
-for my $name (@ln)
+if (not $force)
 {
+ for my $name (@ln)
+  {
     print "Checking ln(s)=$name\n" if ($dryrun);
 
     my @s = getpwnam($name);
@@ -175,6 +181,7 @@ for my $name (@ln)
         print "Result: $res\n" if ($dryrun);
         exit(1);
     }
+  }
 }
 
 print "Local Name(s)=($lnstring) is/are valid. Requested entry will be added.\n"

--- a/gsi/gss_assist/source/programs/grid-mapfile-add-entry.in
+++ b/gsi/gss_assist/source/programs/grid-mapfile-add-entry.in
@@ -60,6 +60,7 @@ Options:
   -mapfile FILE, -f FILE  Path of Grid map file to be used
 
   -force                  Make modifications even if user does not exist (needed for B2STAGE)
+
 EOF
 }
 

--- a/gsi/gss_assist/source/programs/grid-mapfile-add-entry.in
+++ b/gsi/gss_assist/source/programs/grid-mapfile-add-entry.in
@@ -41,7 +41,7 @@ my $GRID_MAP_FILE = $ENV{GRIDMAP} || "${secconfdir}/grid-mapfile";
 my $dryrun = 0;
 my $force = 0;
 
-my $short_usage="$PROGRAM_NAME -dn DN -ln LN [-help] [-d] [-f mapfile FILE]";
+my $short_usage="$PROGRAM_NAME -dn DN -ln LN [-help] [-d] [-f mapfile FILE] [-force]";
 
 sub long_usage
 {

--- a/gsi/gss_assist/source/programs/grid-mapfile-add-entry.txt
+++ b/gsi/gss_assist/source/programs/grid-mapfile-add-entry.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 --------
 *grid-mapfile-add-entry* [ -h | -help | -usage | -version | -versions ]
 
-*grid-mapfile-add-entry* -dn 'DISTINGUISHED-NAME' -ln 'LOCAL-NAME'...  [-d | -dryrun] [ -f 'MAPFILE' | -mapfile 'MAPFILE' ] [ -n ] [ -c ]
+*grid-mapfile-add-entry* -dn 'DISTINGUISHED-NAME' -ln 'LOCAL-NAME'...  [-d | -dryrun] [ -f 'MAPFILE' | -mapfile 'MAPFILE' ] [-force] [ -n ] [ -c ] 
 
 DESCRIPTION
 -----------
@@ -56,7 +56,7 @@ The full set of command-line options to *grid-mapfile-add-entry* are:
     The POSIX user name to map the distinguished name to. This name must be a
     valid username. Add multiple 'LOCAL-NAME' strings after the '-ln'
     command-line option. If any of the local names are invalid, no changes will
-    be made to the gridmap file. 
+    be made to the gridmap file (but see force option below). 
 
 *-d, -dryrun*::
     Verify local names and display diagnostics about what would be added to the
@@ -64,6 +64,9 @@ The full set of command-line options to *grid-mapfile-add-entry* are:
 
 *-mapfile 'MAPFILE', -f 'MAPFILE'*::
     Modify the gridmap file named by 'MAPFILE' instead of the default.
+
+*-force::
+    Make modifications even if user does not exist (needed for B2STAGE).
 
 *-n*::
     Don't copy the original file to 'MAPFILE'.old.

--- a/gsi/gss_assist/source/programs/grid-mapfile-add-entry.txt
+++ b/gsi/gss_assist/source/programs/grid-mapfile-add-entry.txt
@@ -65,7 +65,7 @@ The full set of command-line options to *grid-mapfile-add-entry* are:
 *-mapfile 'MAPFILE', -f 'MAPFILE'*::
     Modify the gridmap file named by 'MAPFILE' instead of the default.
 
-*-force::
+*-force*::
     Make modifications even if user does not exist (needed for B2STAGE).
 
 *-n*::


### PR DESCRIPTION
When using gtc and EUDAT B2STAGE, the users may not be connected to the unix users in the machine (e.g. if authorization uses OpenID tokens).
I added an option to allow modification of the gridmap file even if the unix user does not exist (-f -- force)