### PR TITLE
Keep admin script in sync with init script

### DIFF
--- a/gram/jobmanager/scheduler_event_generator/source/configure.ac
+++ b/gram/jobmanager/scheduler_event_generator/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_scheduler_event_generator],[6.3],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_scheduler_event_generator],[6.4],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gram/jobmanager/scheduler_event_generator/source/globus-scheduler-event-generator-admin.in
+++ b/gram/jobmanager/scheduler_event_generator/source/globus-scheduler-event-generator-admin.in
@@ -28,8 +28,7 @@ GLOBUS_SEG_CONFIG=${GLOBUS_SEG_CONFIG:-@SEG_CONFIGDIR@/@SEG_CONFIGFILE@}
 test -f "${GLOBUS_SEG_CONFIG}" && . "${GLOBUS_SEG_CONFIG}"
 
 # Keep in sync with init script
-GLOBUS_SEG_PIDDIR="${GLOBUS_SEG_PIDDIR:-${localstatedir}/run/}"
-GLOBUS_SEG_PIDFMT="${GLOBUS_SEG_PIDDIR}/globus-scheduler-event-generator-%s.pid"
+GLOBUS_SEG_PIDFMT="${GLOBUS_SEG_PIDFMT:-${localstatedir}/run/globus-scheduler-event-generator-%s.pid}"
 GLOBUS_SEG_LRM_DIR="${GLOBUS_SEG_LRM_DIR:-${sysconfdir}/globus/scheduler-event-generator}"
 
 enable=""

--- a/packaging/debian/globus-scheduler-event-generator/debian/changelog.in
+++ b/packaging/debian/globus-scheduler-event-generator/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-scheduler-event-generator (6.4-1+gct.@distro@) @distro@; urgency=medium
+
+  * Keep admin script in sync with init script
+
+ -- Mattias Ellert <ellert@localhost>  Thu, 17 Dec 2020 09:59:20 +0100
+
 globus-scheduler-event-generator (6.3-1+gct.@distro@) @distro@; urgency=medium
 
   * Remove unused TESTS.pl script

--- a/packaging/fedora/globus-scheduler-event-generator.spec
+++ b/packaging/fedora/globus-scheduler-event-generator.spec
@@ -3,8 +3,8 @@
 Name:		globus-scheduler-event-generator
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	6.3
-Release:	2%{?dist}
+Version:	6.4
+Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Scheduler Event Generator
 
 Group:		System Environment/Libraries
@@ -239,6 +239,9 @@ fi
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Thu Dec 17 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.4-1
+- Keep admin script in sync with init script
+
 * Tue Mar 10 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.3-2
 - Add BuildRequires perl-interpreter
 - Add additional perl dependencies for tests


### PR DESCRIPTION
Even though there is a comment in the admin script that says:
  # Keep in sync with init script
the admin script is not in sync with the init script.
This commit corrects this.

The admin script ignored the GLOBUS_SEG_PIDFMT setting in the
sysconfig file that the init script uses. With the default value they
still did the same, and there is usually no need to change the
default, so it usually worked anyway.