### PR TITLE
Update default run directory from /var/run to /run

### DIFF
--- a/myproxy/source/VERSION
+++ b/myproxy/source/VERSION
@@ -4,6 +4,9 @@ Binary compatibility of the C API is not guaranteed between releases.
 
 Version History
 ---------------
+v6.2.8
+- Update default run directory from /var/run to /run
+
 v6.2.7
 - Exit with error if voms-proxy-init fails
 

--- a/myproxy/source/configure.ac
+++ b/myproxy/source/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT([myproxy],[6.2.7])
+AC_INIT([myproxy],[6.2.8])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign])
 LT_INIT([dlopen win32-dll])

--- a/myproxy/source/myproxy.init.sles
+++ b/myproxy/source/myproxy.init.sles
@@ -30,7 +30,7 @@ X509_USER_CERT=/etc/grid-security/myproxy/hostcert.pem
 X509_USER_KEY=/etc/grid-security/myproxy/hostkey.pem
 export X509_USER_CERT
 export X509_USER_KEY
-PIDFILE=/var/run/myproxy.pid
+PIDFILE=/run/myproxy.pid
 
 # Override defaults here.
 [ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog

--- a/myproxy/source/myproxy_server.c
+++ b/myproxy/source/myproxy_server.c
@@ -320,7 +320,7 @@ main(int argc, char *argv[])
         /* no exit() allowed before become_daemon_step3() call */
 
        if (getuid() == 0 && !server_context->pidfile) {
-           server_context->pidfile = "/var/run/myproxy.pid";
+           server_context->pidfile = "/run/myproxy.pid";
        }
        if (server_context->pidfile) {
            /* It'd be nice to call pidfile_open() before forking the

--- a/myproxy/source/systemd/myproxy-server.conf
+++ b/myproxy/source/systemd/myproxy-server.conf
@@ -1,1 +1,1 @@
-D /var/run/myproxy-server 0710 myproxy root -
+D /run/myproxy-server 0710 myproxy root -

--- a/myproxy/source/systemd/myproxy-server.service
+++ b/myproxy/source/systemd/myproxy-server.service
@@ -11,9 +11,9 @@ Type=forking
 User=myproxy
 Environment=X509_USER_CERT=/etc/grid-security/myproxy/hostcert.pem
 Environment=X509_USER_KEY=/etc/grid-security/myproxy/hostkey.pem
-ExecStart=/usr/sbin/myproxy-server --pidfile /var/run/myproxy-server/myproxy.pid
+ExecStart=/usr/sbin/myproxy-server --pidfile /run/myproxy-server/myproxy.pid
 ExecReload=/bin/kill -HUP $MAINPID
-PIDFile=/var/run/myproxy-server/myproxy.pid
+PIDFile=/run/myproxy-server/myproxy.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/debian/myproxy/debian/changelog.in
+++ b/packaging/debian/myproxy/debian/changelog.in
@@ -1,3 +1,9 @@
+myproxy (6.2.8-1+gct.@distro@) @distro@; urgency=medium
+
+  * Update default run directory from /var/run to /run
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Thu, 04 Mar 2021 07:59:54 +0100
+
 myproxy (6.2.7-1+gct.@distro@) @distro@; urgency=medium
 
   * Exit with error if voms-proxy-init fails

--- a/packaging/fedora/myproxy.spec
+++ b/packaging/fedora/myproxy.spec
@@ -2,7 +2,7 @@
 
 Name:           myproxy
 %global soname 6
-Version:        6.2.7
+Version:        6.2.8
 Release:        1%{?dist}
 Summary:        Manage X.509 Public Key Infrastructure (PKI) security credentials
 
@@ -387,6 +387,9 @@ fi
 %doc %{_pkgdocdir}/LICENSE*
 
 %changelog
+* Thu Mar 04 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.8-1
+- Update default run directory from /var/run to /run
+
 * Thu Mar 04 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.7-1
 - Exit with error if voms-proxy-init fails
 


### PR DESCRIPTION
Filesystem Hierarchy Standard 3.0 says about /var/run:
"This directory was once intended for system information data
describing the system since it was booted. These functions have been
moved to /run."

Using /var/run in systemd unit files and tmpfiles.d config files
results in warnings in the logs:

Dec 23 12:42:25 localhost.localdomain systemd[1]: /usr/lib/systemd/system/myproxy-server.service:16: PIDFile= references a path below legacy directory /var/run/, updating /var/run/myproxy-server/myproxy.pid → /run/myproxy-server/myproxy.pid; please update the unit file accordingly.

/usr/lib/tmpfiles.d/myproxy-server.conf:1: Line references path below legacy directory /var/run/, updating /var/run/myproxy-server → /run/myproxy-server; please update the tmpfiles.d/ drop-in file accordingly.