### PR TITLE
Fix name matching for Doxygen

### DIFF
--- a/common/source/test/globus_test_tap.h
+++ b/common/source/test/globus_test_tap.h
@@ -2,7 +2,7 @@
 #include <stdio.h>
 
 /**
- * @file globus_test_tap.h
+ * @file
  * @brief Test Anything Protocol implementation
  */
 

--- a/gridftp/net_manager/attr/destroy.c
+++ b/gridftp/net_manager/attr/destroy.c
@@ -15,7 +15,7 @@
  */
 
 /**
- * @file destroy.c
+ * @file
  * @brief globus_net_manager_attr_destroy()
  */
 

--- a/gridftp/net_manager/attr/init.c
+++ b/gridftp/net_manager/attr/init.c
@@ -15,7 +15,7 @@
  */
 
 /**
- * @file init.c
+ * @file
  * @brief globus_net_manager_attr_init()
  */
 

--- a/gridftp/net_manager/context/destroy.c
+++ b/gridftp/net_manager/context/destroy.c
@@ -15,7 +15,7 @@
  */
 
 /**
- * @file destroy.c
+ * @file
  * @brief globus_net_manager_context_destroy()
  */
 

--- a/gridftp/net_manager/context/init.c
+++ b/gridftp/net_manager/context/init.c
@@ -15,7 +15,7 @@
  */
 
 /**
- * @file init.c
+ * @file
  * @brief globus_net_manager_context_init()
  */
 

--- a/gridftp/net_manager/test/globus_test_tap.h
+++ b/gridftp/net_manager/test/globus_test_tap.h
@@ -2,7 +2,7 @@
 #include <stdio.h>
 
 /**
- * @file globus_test_tap.h
+ * @file
  * @brief Test Anything Protocol implementation
  */
 

--- a/gsi/gss_assist/source/read_vhost_cred_dir.c
+++ b/gsi/gss_assist/source/read_vhost_cred_dir.c
@@ -15,7 +15,7 @@
  */
 
 /**
- * @file read_vhost_cred_dir.c
+ * @file
  * @brief Read all credentials in a directory
  */
 

--- a/gsi/gssapi/source/library/read_vhost_cred_dir.c
+++ b/gsi/gssapi/source/library/read_vhost_cred_dir.c
@@ -15,7 +15,7 @@
  */
 
 /**
- * @file read_vhost_cred_dir.c
+ * @file
  * @brief Read all credentials in a directory
  */
 


### PR DESCRIPTION
...by avoiding file names for the `\file` command in the files
changed with this commit. See https://www.doxygen.nl/manual/commands.html#cmdfile
for details.

Fixes #109.