### PR TITLE
Upload to "hcc-osg-repo.unl.edu"

### DIFF
--- a/travis-ci/upload_source_tarballs.sh
+++ b/travis-ci/upload_source_tarballs.sh
@@ -11,10 +11,10 @@ keyfile=$(pwd -P)/travis-ci/id_gctuploader
 
 # also hosts repo.gridcf.org; can't use repo.gridcf.org directly because
 # CloudFlare apparently doesn't properly handle SSH
-upload_server=repo.opensciencegrid.org
+upload_server=hcc-osg-repo.unl.edu
 
-# obtained by running "ssh-keyscan repo.opensciencegrid.org"
-hostsig="repo.opensciencegrid.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2AIWAVx2KY+GhDab9SdxLTvjjzTiNa4pfHe7TvRZ5O+qZNc4c8sBlsG7OZGZvDLMRjGTKFyjJx3jDVUwaf14DwzQi9rgZxEZgBsRFffLATZqz+DyVN1H9uw215pah9Wh6yzaqMn51y6kqg0kk/ip62cYcXFgLKUNkzV0yz5WFugm5ziROZn01v5o74VdCABTAdlZhviUoObCn+bycXoUGGETY5GZ3muAW6y5LydDTD+2S97qJWGdSW7JBIfcmU7n5dl8MrtYKYwGswOgdUDrLtCp6CdZt/Evr+3NyLp35IhLnwxdkBBlKHPY0jXrGHyemsXa0Hq0PG/Ih5d0M8RMp"
+# obtained by running "ssh-keyscan hcc-osg-repo.unl.edu"
+hostsig="hcc-osg-repo.unl.edu ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2AIWAVx2KY+GhDab9SdxLTvjjzTiNa4pfHe7TvRZ5O+qZNc4c8sBlsG7OZGZvDLMRjGTKFyjJx3jDVUwaf14DwzQi9rgZxEZgBsRFffLATZqz+DyVN1H9uw215pah9Wh6yzaqMn51y6kqg0kk/ip62cYcXFgLKUNkzV0yz5WFugm5ziROZn01v5o74VdCABTAdlZhviUoObCn+bycXoUGGETY5GZ3muAW6y5LydDTD+2S97qJWGdSW7JBIfcmU7n5dl8MrtYKYwGswOgdUDrLtCp6CdZt/Evr+3NyLp35IhLnwxdkBBlKHPY0jXrGHyemsXa0Hq0PG/Ih5d0M8RMp"
 
 
 echo "$hostsig" > ~/.ssh/known_hosts


### PR DESCRIPTION
This is the actual machine that hosts repo.gridcf.org.  We can't SFTP to
that alias because it's a CloudFlare redirect and, according to my
comment, "doesn't properly handle SSH".

The hosting duty for the OSG repos has moved to a different machine so
repo.opensciencegrid.org no longer points to the machine we used to
upload to.  Upload to hcc-osg-repo.unl.edu instead.