### PR TITLE
Fix for segmentation fault with tilde:

### DIFF
--- a/gass/copy/source/configure.ac
+++ b/gass/copy/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gass_copy],[10.8],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gass_copy],[10.9],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gass/copy/source/globus_url_copy.c
+++ b/gass/copy/source/globus_url_copy.c
@@ -1097,15 +1097,21 @@ globus_l_guc_glob_list_cb(
     else
     {
         end_ndx = strlen(url_info.url_path) - 1;
-        if(url_info.url_path[end_ndx] == '/' && end_ndx > 0)
+        if(end_ndx > 0 && url_info.url_path[end_ndx] == '/')
         {
             url_info.url_path[end_ndx] = '\0';
             end_ch = '/';
         }
 
         tmp_str = strrchr(url_info.url_path, '/');
-        *tmp_str = '\0';
-        tmp_str++;
+        if (tmp_str) {
+            *tmp_str = '\0';
+            tmp_str++;
+        }
+        else
+        {
+            tmp_str = url_info.url_path;
+        }
         printf("    %s%c\n", tmp_str, end_ch);
     }
     globus_url_destroy(&url_info);

--- a/packaging/debian/globus-gass-copy/debian/changelog.in
+++ b/packaging/debian/globus-gass-copy/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gass-copy (10.9-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix segmentation fault with ~
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Tue, 22 Jun 2021 16:16:13 +0200
+
 globus-gass-copy (10.8-1+gct.@distro@) @distro@; urgency=medium
 
   * Document environment variables in globus-url-copy manpage

--- a/packaging/fedora/globus-gass-copy.spec
+++ b/packaging/fedora/globus-gass-copy.spec
@@ -3,7 +3,7 @@
 Name:		globus-gass-copy
 %global soname 2
 %global _name %(echo %{name} | tr - _)
-Version:	10.8
+Version:	10.9
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gass Copy
 
@@ -183,6 +183,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Tue Jun 22 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.9-1
+- Fix segmentation fault with ~
+
 * Sat Sep 12 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.8-1
 - Document environment variables in globus-url-copy manpage
 


### PR DESCRIPTION
```
globus-url-copy -list gsiftp://localhost/~
gsiftp://localhost/~
Segmentation fault (core dumped)
```
