### PR TITLE
Fix for gsi openssh builds on centos 7

### DIFF
--- a/gsi_openssh/source/ssh-rsa.c
+++ b/gsi_openssh/source/ssh-rsa.c
@@ -53,6 +53,16 @@ rsa_hash_alg_ident(int hash_alg)
 	return NULL;
 }
 
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+static int RSA_bits(const RSA *r);
+
+static int
+RSA_bits(const RSA *r)
+{
+    return BN_num_bits(r->n);
+}
+#endif
+
 /*
  * Returns the hash algorithm ID for a given algorithm identifier as used
  * inside the signature blob,

--- a/travis-ci/build_and_test.sh
+++ b/travis-ci/build_and_test.sh
@@ -10,7 +10,6 @@ cd "$root"
 
 args=(--prefix="$root" --enable-silent-rules)
 if [[ $COMPONENTS != *ssh* ]]; then
-    rm -f prep-gsissh
     args+=(--disable-gsi-openssh)
 fi
 if [[ $COMPONENTS == *gram5* ]]; then

--- a/travis-ci/run_task_inside_docker.sh
+++ b/travis-ci/run_task_inside_docker.sh
@@ -30,7 +30,8 @@ yum clean all
 packages=(gcc gcc-c++ make autoconf automake libtool \
           libtool-ltdl-devel openssl openssl-devel git \
           'perl(Test)' 'perl(Test::More)' 'perl(File::Spec)' \
-          'perl(URI)' file sudo bison patch curl)
+          'perl(URI)' file sudo bison patch curl \
+          pam pam-devel libedit libedit-devel)
 
 if [[ $TASK == tests ]]; then
     set +e
@@ -56,6 +57,8 @@ elif [[ $TASK == *rpms ]]; then
     packages+=(redhat-lsb-core)
     # for myproxy-oauth
     packages+=(m2crypto mod_ssl mod_wsgi pyOpenSSL python-crypto)
+    # for gsi-openssh
+    packages+=(pam libedit libedit-devel)
 fi
 
 


### PR DESCRIPTION
As per https://github.com/gridcf/gct/pull/154#issuecomment-894463701 and following comments, this PR should fix the build problems introduced with #154.

Again much thanks to @msalle for providing a patch that makes GSI-OpenSSH w/HPN 8.6p1 compile with OpenSSL version 1.0.x (as shipped with CentOS 7, which is used on Travis CI for our build tests).