### PR TITLE
More OpenSSL3.0 fixes, for 3.0-beta2

### DIFF
--- a/gsi/openssl_error/source/configure.ac
+++ b/gsi/openssl_error/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gsi_openssl_error], [4.2],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gsi_openssl_error], [4.3],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gsi/openssl_error/source/library/globus_error_openssl.c
+++ b/gsi/openssl_error/source/library/globus_error_openssl.c
@@ -892,7 +892,10 @@ globus_error_match_openssl_error(
         
     
     if(library == ERR_GET_LIB(instance_data->error_code) &&
+/* Note that in OpenSSL 3.0 ERR_GET_FUNC is no longer there */
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
        function == ERR_GET_FUNC(instance_data->error_code) &&
+#endif
        reason == ERR_GET_REASON(instance_data->error_code))
     {
         return GLOBUS_TRUE;

--- a/gsi_openssh/source/dh.c
+++ b/gsi_openssh/source/dh.c
@@ -44,6 +44,7 @@
 #include "ssherr.h"
 
 #include "openbsd-compat/openssl-compat.h"
+#include "fips_mode_replacement.h"
 
 static const char *moduli_filename;
 

--- a/gsi_openssh/source/fips_mode_replacement.h
+++ b/gsi_openssh/source/fips_mode_replacement.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021- Grid Community Forum
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+/*
+ * OpenSSL version 3.0 and up no longer has FIPS_mode().
+ * Making a replacement function is not feasible since FIPS would need to be
+ * initialized differently in any case.
+ * See https://www.openssl.org/docs/manmaster/man7/fips_module.html for details
+ */
+# define FIPS_mode() 0
+#endif

--- a/gsi_openssh/source/kex.c
+++ b/gsi_openssh/source/kex.c
@@ -44,6 +44,7 @@
 # include <openssl/kdf.h>
 # endif
 #endif
+#include "fips_mode_replacement.h"
 
 #include "ssh.h"
 #include "ssh2.h"

--- a/gsi_openssh/source/kexgexc.c
+++ b/gsi_openssh/source/kexgexc.c
@@ -39,6 +39,7 @@
 #include <signal.h>
 
 #include "openbsd-compat/openssl-compat.h"
+#include "fips_mode_replacement.h"
 
 #include "sshkey.h"
 #include "cipher.h"

--- a/gsi_openssh/source/readconf.c
+++ b/gsi_openssh/source/readconf.c
@@ -69,6 +69,7 @@
 #include "digest.h"
 #include "sshbuf.h"
 #include "ssh-gss.h"
+#include "fips_mode_replacement.h"
 
 /* Format of the configuration file:
 

--- a/gsi_openssh/source/servconf.c
+++ b/gsi_openssh/source/servconf.c
@@ -72,6 +72,7 @@
 #include "digest.h"
 #include "sshbuf.h"
 #include "ssh-gss.h"
+#include "fips_mode_replacement.h"
 
 static void add_listen_addr(ServerOptions *, const char *,
     const char *, int);

--- a/gsi_openssh/source/ssh-keygen.c
+++ b/gsi_openssh/source/ssh-keygen.c
@@ -23,6 +23,7 @@
 #include <openssl/pem.h>
 #include "openbsd-compat/openssl-compat.h"
 #endif
+#include "fips_mode_replacement.h"
 
 #ifdef HAVE_STDINT_H
 # include <stdint.h>

--- a/gsi_openssh/source/ssh.c
+++ b/gsi_openssh/source/ssh.c
@@ -80,6 +80,7 @@
 #include <openssl/crypto.h>
 #include "openbsd-compat/openssl-compat.h"
 #include "openbsd-compat/sys-queue.h"
+#include "fips_mode_replacement.h"
 
 #include "xmalloc.h"
 #include "ssh.h"

--- a/gsi_openssh/source/sshconnect2.c
+++ b/gsi_openssh/source/sshconnect2.c
@@ -46,6 +46,7 @@
 #endif
 
 #include <openssl/crypto.h>
+#include "fips_mode_replacement.h"
 
 #include "openbsd-compat/sys-queue.h"
 

--- a/gsi_openssh/source/sshd.c
+++ b/gsi_openssh/source/sshd.c
@@ -81,6 +81,7 @@
 #include <openssl/crypto.h>
 #include "openbsd-compat/openssl-compat.h"
 #endif
+#include "fips_mode_replacement.h"
 
 #ifdef HAVE_SECUREWARE
 #include <sys/security.h>

--- a/gsi_openssh/source/sshkey.c
+++ b/gsi_openssh/source/sshkey.c
@@ -36,6 +36,7 @@
 #include <openssl/pem.h>
 #include <openssl/crypto.h>
 #endif
+#include "fips_mode_replacement.h"
 
 #include "crypto_api.h"
 

--- a/packaging/debian/globus-gsi-openssl-error/debian/changelog.in
+++ b/packaging/debian/globus-gsi-openssl-error/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gsi-openssl-error (4.3-1+gct.@distro@) @distro@; urgency=medium
+
+  * More OpenSSL3.0 fixes, for 3.0-beta2
+
+ -- Frank Scheiner <scheiner@hlrs.de> Thu, 12 Aug 2021 16:28:40 +0200
+
 globus-gsi-openssl-error (4.2-1+gct.@distro@) @distro@; urgency=medium
 
   * Make makefiles exit sooner on errors

--- a/packaging/fedora/globus-gsi-openssl-error.spec
+++ b/packaging/fedora/globus-gsi-openssl-error.spec
@@ -3,8 +3,8 @@
 Name:		globus-gsi-openssl-error
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	4.2
-Release:	2%{?dist}
+Version:	4.3
+Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus OpenSSL Error Handling
 
 Group:		System Environment/Libraries
@@ -142,6 +142,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Thu Aug 12 2021 Frank Scheiner <scheiner@hlrs.de> - 4.3-1
+- More OpenSSL3.0 fixes, for 3.0-beta2
+
 * Tue Mar 10 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 4.2-2
 - Add BuildRequires perl-interpreter
 - Add additional perl dependencies for tests


### PR DESCRIPTION
OpenSSL 3.0 beta2 has removed a few functions:
- `ERR_GET_FUNC()` is no longer there and there is no simple replacement, so we best just comment out the one place it occurs.
- gsi_openssh (which we now include) uses `FIPS_mode()` which no longer exists in 3.0. Also here there is no easy replacement, since FIPS mode is quite differently enabled in 3.0. We add a macro via the new `fips_mode_replacement.h` that simply returns 0.