### PR TITLE
Use -l (--listen) flag when starting myproxy-server in test scripts

### DIFF
--- a/myproxy/source/configure.ac
+++ b/myproxy/source/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT([myproxy],[6.2.8])
+AC_INIT([myproxy],[6.2.9])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign])
 LT_INIT([dlopen win32-dll])

--- a/myproxy/source/man/myproxy-server.config.5
+++ b/myproxy/source/man/myproxy-server.config.5
@@ -686,7 +686,7 @@ utility.
 This value is for use with the 
 .BR myproxy-replicate (1)
 utility.  This tag provides a list of servers that will be used as secondary
-repositories for the MyProxy database.  Each server should be seperated by
+repositories for the MyProxy database.  Each server should be separated by
 a ";".  Also, a port may be provided if the slave server is using a port
 other then the default.  The server name maybe a recognized DNS or an IP
 address.
@@ -779,7 +779,7 @@ are set.
 .TP
 .BI ocsp_responder_cert " path"
 Specifies the path to the certificate of a trusted OCSP responder.
-This is needed if the OCSP responder must be explicity trusted in
+This is needed if the OCSP responder must be explicitly trusted in
 cases where standard path validation fails for the OCSP responder's
 certificate.
 .SH REGULAR EXPRESSIONS

--- a/myproxy/source/myproxy-server.config
+++ b/myproxy/source/myproxy-server.config
@@ -611,9 +611,9 @@
 #	FQDN
 #	tcp/ip address
 #
-# The host name and port number must be seperated by a ':'.
+# The host name and port number must be separated by a ':'.
 #
-# If multiple slaves are given, each slave server must be seperated with
+# If multiple slaves are given, each slave server must be separated with
 # a ';'.
 #
 #
@@ -697,7 +697,7 @@
 # OCSP Responder Certificate
 #
 # Specifies the path to the certificate of a trusted OCSP responder.
-# This is needed if the OCSP responder must be explicity trusted in
+# This is needed if the OCSP responder must be explicitly trusted in
 # cases where standard path validation fails for the OCSP responder's
 # certificate.
 #ocsp_responder_cert /etc/grid-security/trustedocspresponder.pem

--- a/myproxy/source/myproxy-test
+++ b/myproxy/source/myproxy-test
@@ -267,7 +267,8 @@ if ($startserver) {
     $SERVERPIDFILE = "$tmpdir/myproxy-test.serverpid.$$";
     $SERVERPORTFILE = "$tmpdir/myproxy-test.serverport.$$";
     $servercmd = "$myproxy_server -s $serverdir -c $serverconf";
-    $servercmd .= " -p 0 -P $SERVERPIDFILE -z $SERVERPORTFILE";
+    $servercmd .= " -l $ENV{'MYPROXY_SERVER'} -p 0";
+    $servercmd .= " -P $SERVERPIDFILE -z $SERVERPORTFILE";
     if (defined($valgrind)) {
         $valgrindlog = File::Temp::tempnam($tmpdir, "valgrind.log.");
         $valgrindlogopt = " --log-file=$valgrindlog ";

--- a/myproxy/source/myproxy-test-replicate
+++ b/myproxy/source/myproxy-test-replicate
@@ -259,7 +259,8 @@ chmod(0700, $sl1dir) ||
 $sl1pidfile = "$tmpdir/myproxy-test.serverpid.sl1.$$";
 $sl1portfile = "$tmpdir/myproxy-test.serverport.sl1.$$";
 $servercmd = "$myproxy_server -s $sl1dir -c $slconf";
-$servercmd .= " -p 0 -P $sl1pidfile -z $sl1portfile";
+$servercmd .= " -l $ENV{'MYPROXY_SERVER'} -p 0";
+$servercmd .= " -P $sl1pidfile -z $sl1portfile";
 &debug("running '$servercmd'");
 `$servercmd`;
 sleep(2);			# give server a chance to startup

--- a/myproxy/source/myproxy.c
+++ b/myproxy/source/myproxy.c
@@ -2740,7 +2740,7 @@ myproxy_request_add_voname(myproxy_request_t *client_request,
         }
     } else {
         if (my_append(&(client_request->voname), "\n", voname, NULL) < 0) {
-            verror_put_string("my_append faild");
+            verror_put_string("my_append failed");
             goto error;
         }
     }
@@ -2775,7 +2775,7 @@ myproxy_request_add_vomses(myproxy_request_t *client_request,
         }
     } else {
         if (my_append(&(client_request->vomses), "\n", vomses, NULL) < 0) {
-            verror_put_string("my_append faild");
+            verror_put_string("my_append failed");
             goto error;
         }
     }
@@ -3145,7 +3145,7 @@ encode_response(const myproxy_proto_response_type_t	response_value)
       default:
 	/* Should never get here */
 	string = NULL;
-	verror_put_string("Internal error: Bad reponse type (%d)",
+	verror_put_string("Internal error: Bad response type (%d)",
 			  response_value);
 	break;
     }

--- a/myproxy/source/safe_is_path_trusted.c
+++ b/myproxy/source/safe_is_path_trusted.c
@@ -449,7 +449,7 @@ static void destroy_dir_stack(dir_stack* stack)
  *	path
  *		path to push on the stack.  A copy is made.
  * returns
- *	0  on sucess
+ *	0  on success
  *	<0 on error (if the stack if contains MAX_SYMLINK_DEPTH directories
  *		errno = ELOOP for detecting symbolic link loops
  */
@@ -493,7 +493,7 @@ static int push_path_on_stack(dir_stack* stack, const char* path)
  *	path
  *		pointer to a pointer to store the next component
  * returns
- *	0  on sucess
+ *	0  on success
  *	<0 on stack empty
  */
 static int get_next_component(dir_stack* stack, const char **path)

--- a/myproxy/source/voms_utils.h
+++ b/myproxy/source/voms_utils.h
@@ -28,8 +28,8 @@ char **get_vomses(const char *path);
  * has_voms_extension()
  *
  * Returns 1 if specified file has VOMS extension.
- * Returns 0 if specified file has not VOMS extension.
- * Returns -1 if error was occured.
+ * Returns 0 if specified file has no VOMS extension.
+ * Returns -1 if error occurred.
  */
 int has_voms_extension(const char *certfilepath);
 

--- a/packaging/debian/myproxy/debian/changelog.in
+++ b/packaging/debian/myproxy/debian/changelog.in
@@ -1,6 +1,7 @@
 myproxy (6.2.9-1+gct.@distro@) @distro@; urgency=medium
 
   * Use -l (--listen) flag when starting myproxy-server in test scripts
+  * Typo fixes
 
  -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 20 Aug 2021 02:10:01 +0200
 

--- a/packaging/debian/myproxy/debian/changelog.in
+++ b/packaging/debian/myproxy/debian/changelog.in
@@ -1,3 +1,9 @@
+myproxy (6.2.9-1+gct.@distro@) @distro@; urgency=medium
+
+  * Use -l (--listen) flag when starting myproxy-server in test scripts
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 20 Aug 2021 02:10:01 +0200
+
 myproxy (6.2.8-1+gct.@distro@) @distro@; urgency=medium
 
   * Update default run directory from /var/run to /run

--- a/packaging/fedora/myproxy.spec
+++ b/packaging/fedora/myproxy.spec
@@ -389,6 +389,7 @@ fi
 %changelog
 * Fri Aug 20 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.9-1
 - Use -l (--listen) flag when starting myproxy-server in test scripts
+- Typo fixes
 
 * Thu Mar 04 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.8-1
 - Update default run directory from /var/run to /run

--- a/packaging/fedora/myproxy.spec
+++ b/packaging/fedora/myproxy.spec
@@ -2,7 +2,7 @@
 
 Name:           myproxy
 %global soname 6
-Version:        6.2.8
+Version:        6.2.9
 Release:        1%{?dist}
 Summary:        Manage X.509 Public Key Infrastructure (PKI) security credentials
 
@@ -387,6 +387,9 @@ fi
 %doc %{_pkgdocdir}/LICENSE*
 
 %changelog
+* Fri Aug 20 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.9-1
+- Use -l (--listen) flag when starting myproxy-server in test scripts
+
 * Thu Mar 04 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.8-1
 - Update default run directory from /var/run to /run
 


### PR DESCRIPTION
Fix for #160. As proposed in https://github.com/gridcf/gct/issues/160#issuecomment-901860742.

