### PR TITLE
One more openssl 3.0 fix

### DIFF
--- a/gsi/openssl_error/source/configure.ac
+++ b/gsi/openssl_error/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gsi_openssl_error], [4.3],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gsi_openssl_error], [4.4],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gsi/openssl_error/source/test/globus_openssl_error_test.stdout
+++ b/gsi/openssl_error/source/test/globus_openssl_error_test.stdout
@@ -1,4 +1,4 @@
 globus_openssl_error_test: Test Error: blah:\d+
-OpenSSL Error: \S*globus_openssl_error_test.c:\d+: in library: asn1 encoding routines, function i2d_RSA_PUBKEY: decode error
-OpenSSL Error: \S*globus_openssl_error_test.c:\d+: in library: BIO routines, function BIO_write: broken pipe
-OpenSSL Error: \S*globus_openssl_error_test.c:\d+: in library: asn1 encoding routines, function (X509_NAME_(EX_)?NEW|x509_name_(ex_)?new): too long
+OpenSSL Error: \S*globus_openssl_error_test.c:\d+: in library: asn1 encoding routines, function (i2d_RSA_PUBKEY|\(null\)): decode error
+OpenSSL Error: \S*globus_openssl_error_test.c:\d+: in library: BIO routines, function (BIO_write|\(null\)): broken pipe
+OpenSSL Error: \S*globus_openssl_error_test.c:\d+: in library: asn1 encoding routines, function (X509_NAME_(EX_)?NEW|x509_name_(ex_)?new|\(null\)): too long

--- a/packaging/debian/globus-gsi-openssl-error/debian/changelog.in
+++ b/packaging/debian/globus-gsi-openssl-error/debian/changelog.in
@@ -1,8 +1,15 @@
+globus-gsi-openssl-error (4.4-1+gct.@distro@) @distro@; urgency=medium
+
+  * Function names are (null) in OpenSSL 3.0 - adapt expected test
+    output
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 15 Sep 2021 14:29:08 +0200
+
 globus-gsi-openssl-error (4.3-1+gct.@distro@) @distro@; urgency=medium
 
   * More OpenSSL3.0 fixes, for 3.0-beta2
 
- -- Frank Scheiner <scheiner@hlrs.de> Thu, 12 Aug 2021 16:28:40 +0200
+ -- Frank Scheiner <scheiner@hlrs.de>  Thu, 12 Aug 2021 16:28:40 +0200
 
 globus-gsi-openssl-error (4.2-1+gct.@distro@) @distro@; urgency=medium
 

--- a/packaging/fedora/globus-gsi-openssl-error.spec
+++ b/packaging/fedora/globus-gsi-openssl-error.spec
@@ -3,7 +3,7 @@
 Name:		globus-gsi-openssl-error
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	4.3
+Version:	4.4
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus OpenSSL Error Handling
 
@@ -142,6 +142,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Wed Sep 15 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 4.4-1
+- Function names are (null) in OpenSSL 3.0 - adapt expected test output
+
 * Thu Aug 12 2021 Frank Scheiner <scheiner@hlrs.de> - 4.3-1
 - More OpenSSL3.0 fixes, for 3.0-beta2
 


### PR DESCRIPTION
Function names are (null) in OpenSSL 3.0 - adapt expected test output.