### PR TITLE
OpenSSL 3.0 compatibility

### DIFF
--- a/myproxy/source/configure.ac
+++ b/myproxy/source/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT([myproxy],[6.2.9])
+AC_INIT([myproxy],[6.2.10])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign])
 LT_INIT([dlopen win32-dll])

--- a/packaging/debian/myproxy/debian/changelog.in
+++ b/packaging/debian/myproxy/debian/changelog.in
@@ -1,3 +1,9 @@
+myproxy (6.2.10-1+gct.@distro@) @distro@; urgency=medium
+
+  * OpenSSL 3.0 compatibility
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 03 Dec 2021 22:14:17 +0100
+
 myproxy (6.2.9-1+gct.@distro@) @distro@; urgency=medium
 
   * Use -l (--listen) flag when starting myproxy-server in test scripts

--- a/packaging/fedora/myproxy.spec
+++ b/packaging/fedora/myproxy.spec
@@ -2,7 +2,7 @@
 
 Name:           myproxy
 %global soname 6
-Version:        6.2.9
+Version:        6.2.10
 Release:        1%{?dist}
 Summary:        Manage X.509 Public Key Infrastructure (PKI) security credentials
 
@@ -387,6 +387,9 @@ fi
 %doc %{_pkgdocdir}/LICENSE*
 
 %changelog
+* Fri Dec 03 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.10-1
+- OpenSSL 3.0 compatibility
+
 * Fri Aug 20 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.9-1
 - Use -l (--listen) flag when starting myproxy-server in test scripts
 - Typo fixes


### PR DESCRIPTION
Make check succeeds on Fedora 36 with this change.
Fixes #171.
 