### PR TITLE
Fix some compiler and doxygen warnings

### DIFF
--- a/common/source/configure.ac
+++ b/common/source/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.60])
-AC_INIT([globus_common], [18.11], [https://github.com/gridcf/gct/issues])
+AC_INIT([globus_common], [18.12], [https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/common/source/library/globus_args.c
+++ b/common/source/library/globus_args.c
@@ -91,7 +91,7 @@ globus_l_args_create_error_msg( char **        error_msg,
     usage_len = strlen( oneline_usage );
 
     len = strlen(p);
-    strncpy( &p[len], oneline_usage, usage_len );
+    memcpy( &p[len], oneline_usage, usage_len );
     sprintf( &p[len+usage_len], "%s", error_epilogue );
 
     if (error_msg)

--- a/common/source/library/globus_callback.h
+++ b/common/source/library/globus_callback.h
@@ -301,9 +301,6 @@ typedef struct globus_l_callback_space_attr_s * globus_callback_space_attr_t;
  * @param user_arg
  *        The user argument registered with this callback
  *
- * @return
- *        - void
- * 
  * @see globus_callback_space_register_oneshot()
  * @see globus_callback_space_register_periodic()
  * @see globus_thread_blocking_space_will_block()
@@ -576,9 +573,6 @@ globus_callback_adjust_period(
  *        The callback space to poll.  Note: regardless of what space is passed
  *        here, the 'global' space is also always polled.
  *
- * @return
- *        - void
- * 
  * @see globus_callback_spaces
  * @see globus_condattr_setspace()
  */

--- a/common/source/library/globus_error_errno.c
+++ b/common/source/library/globus_error_errno.c
@@ -262,7 +262,6 @@ int
 globus_error_errno_search(
     globus_object_t *                   error)
 {
-    globus_module_descriptor_t *        source_module;
     int                                 current_errno;
     
     if(error == NULL)

--- a/common/source/library/globus_libc.c
+++ b/common/source/library/globus_libc.c
@@ -367,6 +367,7 @@ globus_libc_gethostname(char *name, int len)
         (env = getenv("GLOBUS_HOSTNAME")) != GLOBUS_NULL)
     {
         strncpy(hostname, env, MAXHOSTNAMELEN);
+        hostname[MAXHOSTNAMELEN - 1] = '\0';
         hostname_length = strlen(hostname);
     }
 #endif

--- a/common/source/library/globus_options.c
+++ b/common/source/library/globus_options.c
@@ -114,14 +114,7 @@ globus_l_alphabetize_list(
     }
     else if ((!e1->short_opt) && (!e2->short_opt))
     {
-        if (globus_libc_strncasecmp(e1->short_opt, e2->short_opt, strlen(e1->short_opt)) <= 0)
-        {
-            return GLOBUS_TRUE;
-        }
-        else
-        {
-            return GLOBUS_FALSE;
-        }
+        return GLOBUS_TRUE;
     }
     else if (globus_libc_strncasecmp(e1->short_opt, e2->short_opt, strlen(e1->short_opt)) <= 0)
     {

--- a/common/source/library/globus_thread.c
+++ b/common/source/library/globus_thread.c
@@ -1546,7 +1546,7 @@ globus_thread_self(void)
  * @param thread2
  *     Thread identifier to compare.
  * @retval GLOBUS_TRUE thread1 and thread2 refer to the same thread.
- * @retval GLOBUS_TRUE thread1 and thread2 do not refer to the same thread.
+ * @retval GLOBUS_FALSE thread1 and thread2 do not refer to the same thread.
  */
 globus_bool_t
 globus_thread_equal(

--- a/common/source/test/error_test.c
+++ b/common/source/test/error_test.c
@@ -118,8 +118,6 @@ main()
             char                               *errstring;
             globus_object_t                    *error,
                                                *error2;
-            const globus_object_type_t         *type;
-            int                                 j;
 
             error = globus_error_get(result);
             ok(error != NULL, "error_get_%d", i);

--- a/common/source/test/fifo_test.c
+++ b/common/source/test/fifo_test.c
@@ -43,12 +43,10 @@ int fifo_test(void)
     globus_fifo_t                           currentFifo;
     globus_fifo_t                          *newFifoPtr;
     globus_fifo_t                           relocatedFifo;
-    int                                     rc;
     int                                     numOfItems;
-    int                                    *middleItem;
+    int                                    *middleItem = NULL;
     int                                     middleIndex;
     int                                    *copyData;
-    int                                     errorsOccurred = 0;
 
     printf("1..42\n");
     numOfItems = 8;
@@ -103,7 +101,7 @@ int fifo_test(void)
     /* remove an item in the middle */
     ok((data = (int *)globus_fifo_remove(&currentFifo, middleItem)) != NULL,
         "remove_middle_item");
-    ok(data && (*data == *middleItem), "middle_value_check");
+    ok(data && middleItem && (*data == *middleItem), "middle_value_check");
 
     /* remove an item at the beginning */
     ok((data = globus_fifo_dequeue(&currentFifo)) != NULL, "fifo_dequeue");

--- a/common/source/test/globus_args_scan_test.c
+++ b/common/source/test/globus_args_scan_test.c
@@ -242,8 +242,6 @@ static char * testhnfail[] = {
 int
 main(int argc, char *argv[])
 {
-    int i = 1;
-
     globus_module_activate(GLOBUS_COMMON_MODULE);
 
     printf("1..13\n");

--- a/common/source/test/memory_test.c
+++ b/common/source/test/memory_test.c
@@ -112,7 +112,6 @@ int dump(globus_byte_t * buf, int size)
     int  ctr;
     int  col = 0;
     int failed=0;
-    const char *p = reference_output;
     
     for(ctr = 0; ctr < size; ctr++)
     {

--- a/common/source/test/module_test.c
+++ b/common/source/test/module_test.c
@@ -103,7 +103,6 @@ module_test(void)
     void *                              mod_pointer;
     const char                          *name="GLOBUS_ENV_TEST_VAR";
     char *                              value1 = "value1";
-    int                                 successful_tests=0;
     
 
     printf("1..16\n");
@@ -142,7 +141,7 @@ module_test(void)
      * Activate a module with globus_module_activate()
      */
     rc = globus_module_activate(&module1);
-    ok(rc == GLOBUS_SUCCESS & 
+    ok(rc == GLOBUS_SUCCESS &&
        active_modules[0] == 1 &&
        active_modules[1] == 1 &&
        active_modules[2] == 1, "activate_module1");

--- a/common/source/test/poll_test.c
+++ b/common/source/test/poll_test.c
@@ -188,7 +188,6 @@ adjust_period_set_infinity_callback(
 int
 main(int argc, char *argv[])
 {
-    int                                 tests_passed = 0;
     int                                 ctr;
 
     for (ctr = 0; ctr < argc; ctr++)
@@ -809,7 +808,6 @@ cancel_test()
 void
 verbose_printf(int level, char *s,...)
 {
-    char                                tmp[1023];
     va_list                             ap;
 
 

--- a/common/source/test/timedwait_test.c
+++ b/common/source/test/timedwait_test.c
@@ -50,7 +50,6 @@ int
 timedwait_test(void)
 {
     int			i;
-    int			successful_tests=0;
     globus_reltime_t    delay_time;
     /* Test definitions:
      * time when signal function should be called,

--- a/gass/copy/source/configure.ac
+++ b/gass/copy/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gass_copy],[10.11],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gass_copy],[10.12],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gass/copy/source/globus_gass_copy.h
+++ b/gass/copy/source/globus_gass_copy.h
@@ -648,7 +648,7 @@ typedef struct
  *        The full url to the expanded entry.  A directory entry will end
  *        in a forward slash '/'.
  * 
- * @param stat
+ * @param info_stat
  *        A pointer to a globus_gass_copy_glob_stat_t containing information
  *        about the entry. 
  *

--- a/gass/copy/source/globus_gass_copy_glob.c
+++ b/gass/copy/source/globus_gass_copy_glob.c
@@ -526,7 +526,7 @@ globus_l_gass_copy_glob_expand_ftp_url(
 
     info->base_url = globus_libc_strdup(info->url);
     tmp = strrchr(info->base_url, '/');
-    if(tmp == GLOBUS_NULL || tmp == '\0')
+    if(tmp == GLOBUS_NULL || *tmp == '\0')
     {
         result = globus_error_put(
             globus_error_construct_string(
@@ -942,7 +942,6 @@ globus_l_gass_copy_glob_parse_mlst_line(
     globus_result_t                     result;
     int                                 i;
     char *                              space;
-    char *                              filename;
     char *                              startline;
     char *                              startfact;
     char *                              endfact;
@@ -970,7 +969,6 @@ globus_l_gass_copy_glob_parse_mlst_line(
         goto error_invalid_mlsd;
     }
     *space = '\0';            
-    filename = space + 1;
     startfact = startline;
     
     while(startfact != space)

--- a/gass/copy/source/globus_url_copy.c
+++ b/gass/copy/source/globus_url_copy.c
@@ -3477,16 +3477,16 @@ guc_l_pipe_to_stack_str(
     found = GLOBUS_FALSE;
     while(!found)
     {
-        if(strchr(in_str, *del) == NULL)
+        if(strchr(in_str, *del) != NULL)
         {
             found = GLOBUS_TRUE;
         }
         else
         {
             del++;
-            if(del == '\0')
+            if(*del == '\0')
             {
-                fprintf(stderr, "The pipe string most contain at least one of the following characters: %s", del_choices);
+                fprintf(stderr, "The pipe string must contain at least one of the following characters: %s", del_choices);
                 return NULL;
             }
         }
@@ -3759,7 +3759,7 @@ globus_l_guc_parse_arguments(
             {
                 *tmp_str = '\0';
                 tmp_str++;
-                if(tmp_str == '\0')
+                if(*tmp_str == '\0')
                 {
                     tmp_str = NULL;
                 }

--- a/gass/server_ez/source/configure.ac
+++ b/gass/server_ez/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gass_server_ez],[6.1],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gass_server_ez],[6.2],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gass/server_ez/source/globus_gass_server_ez.c
+++ b/gass/server_ez/source/globus_gass_server_ez.c
@@ -349,7 +349,6 @@ globus_l_gass_server_ez_register_accept_callback(
 					)
 {
     int rc;
-    char * subjectname;
     char * path=NULL;
     FILE *fp;
     char * url;
@@ -358,12 +357,9 @@ globus_l_gass_server_ez_register_accept_callback(
     struct stat	statstruct;
     globus_byte_t * buf;
     int amt;
-    const char *flags;
+    const char *flags = "";
     size_t length;
     uintptr_t buffer_size;
-
-    
-    subjectname=globus_gass_transfer_request_get_subject(request);
 
     globus_l_gass_server_ez_enter();
     /* lookup our options */

--- a/gass/transfer/source/configure.ac
+++ b/gass/transfer/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gass_transfer],[9.3],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gass_transfer],[9.4],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gass/transfer/source/library/globus_gass_transfer_http.c
+++ b/gass/transfer/source/library/globus_gass_transfer_http.c
@@ -2044,7 +2044,7 @@ globus_l_gass_transfer_http_authorization_callback(
     gss_ctx_id_t  				context_handle)
 {
     globus_gass_transfer_http_listener_proto_t *proto;
-    int						rc;
+    int						rc = GLOBUS_FALSE;
     MYNAME(globus_l_gass_transfer_http_authorization_callback);
 
     debug_printf(3, (_GTSL("Entering %s()\n"),myname));

--- a/gass/transfer/source/library/globus_gass_transfer_proto.h
+++ b/gass/transfer/source/library/globus_gass_transfer_proto.h
@@ -124,7 +124,7 @@ typedef void
     globus_gass_transfer_request_proto_t *	proto,
     globus_gass_transfer_request_t		request,
     globus_byte_t *				bytes,
-    globus_size_t				send_length,
+    globus_size_t				bytes_length,
     globus_bool_t				last_data);
 
 /**

--- a/gram/client/source/configure.ac
+++ b/gram/client/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gram_client],[14.5],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gram_client],[14.6],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gram/client/source/globus_gram_client.c
+++ b/gram/client/source/globus_gram_client.c
@@ -339,8 +339,6 @@ globus_i_gram_client_deactivate(void)
  * of the information printed by this debugging system is related to errors
  * that occur during GRAM Client API functions. The messages printed to
  * standard output are not structured in any way.
- *
- * @return void
  */
 void
 globus_gram_client_debug(void)

--- a/gram/client_tools/source/configure.ac
+++ b/gram/client_tools/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gram_client_tools],[12.1],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gram_client_tools],[12.2],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gram/client_tools/source/globusrun.c
+++ b/gram/client_tools/source/globusrun.c
@@ -362,7 +362,6 @@ main(int argc, char* argv[])
     char *                             request_file      = NULL;
     char *                             rm_contact        = NULL;
     char *                             program           = NULL;
-    globus_bool_t                      ignore_ctrlc      = GLOBUS_FALSE;
     globus_rsl_t *                     request_ast       = NULL;
     globus_list_t *                    options_found     = NULL;
     globus_list_t *                    list              = NULL;
@@ -467,7 +466,6 @@ main(int argc, char* argv[])
 
         case arg_n:
             options |= GLOBUSRUN_ARG_IGNORE_CTRLC;
-            ignore_ctrlc = GLOBUS_TRUE;
             break;
 
         case arg_a:

--- a/gram/gatekeeper/source/configure.ac
+++ b/gram/gatekeeper/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gatekeeper],[11.3],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gatekeeper],[11.4],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gram/gatekeeper/source/globus_gatekeeper.c
+++ b/gram/gatekeeper/source/globus_gatekeeper.c
@@ -1494,6 +1494,7 @@ static void doit()
     else if (mapping != NULL)
     {
         strncpy(&identity_buffer[0], mapping, sizeof(identity_buffer));
+        identity_buffer[sizeof(identity_buffer) - 1] = '\0';
     }
 
     userid = identity_buffer;
@@ -2210,16 +2211,19 @@ net_accept(int skt)
 
     while (!gotit)
     {
-	fd_set         fdset;
+	fd_set         fdset1;
+	fd_set         fdset2;
 	struct timeval timeout;
 	int            n;
 
-	FD_ZERO(&fdset);
-	FD_SET(skt, &fdset);
+	FD_ZERO(&fdset1);
+	FD_ZERO(&fdset2);
+	FD_SET(skt, &fdset1);
+	FD_SET(skt, &fdset2);
 	timeout.tv_sec = 60;
 	timeout.tv_usec = 0;
 
-	n = select(skt + 1, &fdset, (fd_set *) 0, &fdset, &timeout);
+	n = select(skt + 1, &fdset1, (fd_set *) 0, &fdset2, &timeout);
 
 	if (n < 0 && errno != EINTR)
 	{

--- a/gram/gatekeeper/source/globus_gatekeeper_utils.c
+++ b/gram/gatekeeper/source/globus_gatekeeper_utils.c
@@ -40,6 +40,7 @@ CVS Information:
 #include <stdio.h>
 #include <stdlib.h>
 #include <locale.h>
+#include <grp.h>
 #include <pwd.h>
 #include <string.h>
 #include <sys/wait.h>
@@ -403,8 +404,10 @@ globus_gatekeeper_util_trans_to_user(struct passwd * pw,
 		if (myuid == pw->pw_uid)
 			return 0;   /* already running as the user */
 		else
+		{
 			*errmsg = strdup("Can not run as another user");
 			return 1;   /* can't run as another user */
+		}
 	}
 
 	/*
@@ -425,29 +428,28 @@ globus_gatekeeper_util_trans_to_user(struct passwd * pw,
 #	elif defined(TARGET_ARCH_SOLARIS) || \
 		 defined(TARGET_ARCH_BSD) || \
 		 defined(TARGET_ARCH_CYGWIN)
-    {
+	{
 		if (setuid(pw->pw_uid) != 0)
 		{
-		    *errmsg = strdup("cannot setuid");
+			*errmsg = strdup("cannot setuid");
 			return -3;
 		}
-    }
+	}
 #	else
-    {
+	{
 		if (seteuid(0) != 0)
 		{
-		    *errmsg = strdup("cannot seteuid");
+			*errmsg = strdup("cannot seteuid");
 			return -4;
 		}
 	
 		if (setreuid(pw->pw_uid, pw->pw_uid) != 0)
 		{
-		    *errmsg = strdup("cannot setreuid");
+			*errmsg = strdup("cannot setreuid");
 			return -5;
 		}
-    }
+	}
 #	endif
 
 	return 0;
-
 }

--- a/gram/gatekeeper/source/globus_k5.c
+++ b/gram/gatekeeper/source/globus_k5.c
@@ -19,11 +19,11 @@
 globus_gram_k5.c
 
 Description:
-	globus to Kerberos simple authentication module. 
+	globus to Kerberos simple authentication module.
 
-	When exec-ed by the gram_gatekeeper after 
-	authentiicating the globus user, this routine 
-	will attempt to issue a command for the user. 
+	When exec-ed by the gram_gatekeeper after
+	authentiicating the globus user, this routine
+	will attempt to issue a command for the user.
 	This may be as simple as a kinit with a password,
 	or can use the NCSA krb525 command, or the
 	sslk5 command to use the X509 user proxy.
@@ -34,30 +34,30 @@ Description:
 	or inetd does.)
 
 	It is expected that the environment will contain the
-	GLOBUSID=globusid of the user and USER=userid for the local 
+	GLOBUSID=globusid of the user and USER=userid for the local
 	unix system.  This program is normaly run as root,
-	and will seteuid before execing the other modules. 
+	and will seteuid before execing the other modules.
 
-	If not run as root, the user should have started the gatekeeper, 	
-	and should already have gotten a K5 credential. 
+	If not run as root, the user should have started the gatekeeper,
+	and should already have gotten a K5 credential.
 
 	The parameters to use and the mapping for the
-	globus to K5 user are located in the 
-	.globuskmap file. 
+	globus to K5 user are located in the
+	.globuskmap file.
 
 	Format of the .globuskmap file:
 		 "globus_user" <kinit command line >... including k5 principal
-	The globus_user may be in "" if it has blanks, such as 
+	The globus_user may be in "" if it has blanks, such as
 	a X509 name.
 	This is designed to be a simple interface, and no attempt
-	to parse or use the command info is made. 
+	to parse or use the command info is made.
 	This allows for other commands to be used instead
 	of kinit. Such as krb525 or sslk5
 
 	This will only be attempted if the gatekeeper
-	is run as root, as if the user has started 
-	the gatekeeper, then he should have a K5 
-	credentials already. 
+	is run as root, as if the user has started
+	the gatekeeper, then he should have a K5
+	credentials already.
 
 CVS Information:
 	$Source$
@@ -84,7 +84,7 @@ Include header files
 #include <sys/stat.h>
 
 #ifdef HAVE_MALLOC_H
-#   include <malloc.h>
+#include <malloc.h>
 #endif
 
 #include "globus_gatekeeper_utils.h"
@@ -130,10 +130,10 @@ Parameters:
 Returns:
 ******************************************************************************/
 int
-globus_gram_k5_kinit(char * globus_client, 
-				struct passwd *pw, 
-				char * user, 
-				char ** errmsgp)
+globus_gram_k5_kinit(char * globus_client,
+                     struct passwd *pw,
+                     char * user,
+                     char ** errmsgp)
 {
 
   int rc;
@@ -144,38 +144,38 @@ globus_gram_k5_kinit(char * globus_client,
   struct stat stx;
 
   if ((rc = globus_gatekeeper_util_globusxmap(getenv("GLOBUSKMAP"),
-			globus_client, &command)))
+                                              globus_client, &command)))
     return(rc); /* not found, or nothing to do */
- 
+
   if (!command)
     return(0); /* no command */
-  
+
   i = 100;
-  if ((rc = globus_gatekeeper_util_tokenize( command, args, &i," \t\n")))
-	return(rc);
+  if ((rc = globus_gatekeeper_util_tokenize(command, args, &i, " \t\n")))
+    return(rc);
 
   if (args[0] == NULL)
-	return(0); /* no command */
+    return(0); /* no command */
 
   i = 0;
   do {
-   sprintf(ccname,"FILE:/tmp/krb5cc_p%d.%d",getpid(),i++);
+    sprintf(ccname, "FILE:/tmp/krb5cc_p%d.%d", getpid(), i++);
   }
-  while(stat(ccname+5,&stx) == 0);
+  while(stat(ccname + 5, &stx) == 0);
 
   globus_libc_setenv("KRB5CCNAME", ccname, 1);
 
-DEEDEBUG2("calling UTIL_exec: user: %s ",user);
-DEEDEBUG2("and uid %d\n",pw?pw->pw_uid:-111111);
-	
+  DEEDEBUG2("calling UTIL_exec: user: %s ", user);
+  DEEDEBUG2("and uid %d\n", pw ? pw->pw_uid : -111111);
+
   rc = globus_gatekeeper_util_exec(args, pw, user, errmsgp);
 
   /*
-   * Make sure the creds cache is owned by the user. 
+   * Make sure the creds cache is owned by the user.
    */
 
   if (rc == 0 && getuid() == 0 && pw) {
-	  (void) chown(ccname+5,pw->pw_uid, pw->pw_gid);
+    (void) chown(ccname + 5, pw->pw_uid, pw->pw_gid);
   }
 
   DEEDEBUG2("globus_gram_k5_exec rc = %d\n", rc);
@@ -203,38 +203,38 @@ main(int argc, char *argv[])
     struct stat stx;
     extern int optind;
     extern char *optarg;
-    uid_t	 myuid;
+    uid_t myuid;
     struct passwd *pw;
     char *errmsg = NULL;
 
 #ifdef DEBUG
-	stderrX = stderr;
- /* stderrX = fopen("/tmp/k5gram.debug","w"); */
+    stderrX = stderr;
+    /* stderrX = fopen("/tmp/k5gram.debug","w"); */
 #endif
 
-	myuid = getuid();  /* get our uid, to see if we are root. */
+    myuid = getuid();  /* get our uid, to see if we are root. */
     DEEDEBUG2("k5gram uid = %lu\n", myuid);
 
-	user = getenv("USER");
-	if (user == NULL)
-	  exit(6); 
-    DEEDEBUG2("USER = %s\n",user);
+    user = getenv("USER");
+    if (user == NULL)
+        exit(6);
+    DEEDEBUG2("USER = %s\n", user);
 
-	pw = getpwnam(user);
-	if (pw == NULL) 
-	  exit(7);
-	DEEDEBUG2("USERID = %lu\n",pw->pw_uid);
+    pw = getpwnam(user);
+    if (pw == NULL)
+        exit(7);
+    DEEDEBUG2("USERID = %lu\n",pw->pw_uid);
 
-	/* if not root, must run as your self */
-	if (myuid && (myuid != pw->pw_uid))
-		exit(8);
+    /* if not root, must run as your self */
+    if (myuid && (myuid != pw->pw_uid))
+        exit(8);
 
-	/* we will need to copy the args, and may add the k5declogin 
-	 * and k5afslogin before. So get three extra. 
-	 */
+    /* we will need to copy the args, and may add the k5declogin
+     * and k5afslogin before. So get three extra.
+     */
 
     if ((newargv = calloc(argc + 3, sizeof(argv[0]))) == NULL) {
-        fprintf(stderr,"Unable to allocate new argv\n");
+        fprintf(stderr, "Unable to allocate new argv\n");
         exit(1);
     }
     ap = newargv;
@@ -243,84 +243,83 @@ main(int argc, char *argv[])
 #ifdef DEBUG
     {
       int i;
-      fprintf(stderrX,"k5gram args: ");
+      fprintf(stderrX, "k5gram args: ");
       i = 0;
       while (argv[i]) {
-        fprintf(stderrX,"%s ",argv[i]);
+        fprintf(stderrX, "%s ", argv[i]);
         i++;
       }
-      fprintf(stderrX,"\n");
+      fprintf(stderrX, "\n");
     }
 #endif
 
     ccname = getenv("KRB5CCNAME");
 
-    /* If there is a cache, then the user must have 
-	 * started the gatekeeper on thier own.
-	 * Or they were running the K5 GSSAPI. So
-	 * don't try and get a K5 cache for them.  
+    /* If there is a cache, then the user must have
+     * started the gatekeeper on thier own.
+     * Or they were running the K5 GSSAPI. So
+     * don't try and get a K5 cache for them.
      */
 
     if (ccname == NULL) {
 
-	  globusid = getenv("GLOBUS_ID");
-	  if (globusid == NULL)
-		goto done;  /* Can't do globus-to-k5 without the globusid */
-      DEEDEBUG2("GLOBUSID = %s\n",globusid);
+        globusid = getenv("GLOBUS_ID");
+        if (globusid == NULL)
+            goto done;  /* Can't do globus-to-k5 without the globusid */
+        DEEDEBUG2("GLOBUSID = %s\n", globusid);
 
-	  if (globus_gram_k5_kinit(globusid, pw, user, &errmsg) == 0) {
-	   ccname = getenv("KRB5CCNAME");
-	  }
+        if (globus_gram_k5_kinit(globusid, pw, user, &errmsg) == 0) {
+            ccname = getenv("KRB5CCNAME");
+        }
 
-	  /* even if the above failed, we want to continue */
-	
+        /* even if the above failed, we want to continue */
     }
 
-	if (ccname) {
-      DEEDEBUG2("KRB5CCNAME = %s\n",ccname);
+    if (ccname) {
+        DEEDEBUG2("KRB5CCNAME = %s\n", ccname);
 
-      /* test if this machine has DCE and k5dcelogin is available.
-       * if so put the k5dcelogin program on the list to call
-       */
+        /* test if this machine has DCE and k5dcelogin is available.
+         * if so put the k5dcelogin program on the list to call
+         */
 
-      if ((stat(K5DCELIB,&stx) == 0) &&
-          (stat(K5DCELOGIN,&stx) == 0)) {
-          *ap++ = K5DCELOGIN;
-          DEEDEBUG2("Will try %s\n",K5DCELOGIN);
-      }
+        if ((stat(K5DCELIB, &stx) == 0) &&
+            (stat(K5DCELOGIN, &stx) == 0)) {
+            *ap++ = K5DCELOGIN;
+            DEEDEBUG2("Will try %s\n", K5DCELOGIN);
+        }
 
-      /* if this system has AFS and not a NFS/AFS translator
-       * put it on the list too
-       */
+        /* if this system has AFS and not a NFS/AFS translator
+         * put it on the list too
+         */
 
 
-      if ((stat("/afs",&stx) == 0) &&
-          (stat(K5AFSLOGIN,&stx) == 0) &&
-          (stat("/usr/vice/etc/ThisCell",&stx) == 0)) {
-          *ap++ = K5AFSLOGIN;
+        if ((stat("/afs", &stx) == 0) &&
+            (stat(K5AFSLOGIN, &stx) == 0) &&
+            (stat("/usr/vice/etc/ThisCell", &stx) == 0)) {
+            *ap++ = K5AFSLOGIN;
 
-          DEEDEBUG2("Will try %s\n",K5AFSLOGIN);
-      }
-	}
+            DEEDEBUG2("Will try %s\n", K5AFSLOGIN);
+        }
+    }
 
 
  done:
     globus_libc_unsetenv("GLOBUSKMAP"); /* dont pass on */
 
-	/* before continuing on, if we were run as root, 
-	 * we will get to user state.
-	 */
+    /* before continuing on, if we were run as root,
+     * we will get to user state.
+     */
 
-	if(globus_gatekeeper_util_trans_to_user(pw, user, &errmsg) != 0) {
+    if((rc = globus_gatekeeper_util_trans_to_user(pw, user, &errmsg))) {
 
-		fprintf(stderr,"Failed to run %d as the user %s %s\n",
-					rc, user, errmsg );
-		exit(3); /* have to fail, since cant run as root */
-	}
+        fprintf(stderr, "Failed to run %d as the user %s %s\n",
+                rc, user, errmsg);
+        exit(3); /* have to fail, since cant run as root */
+    }
 
     /* copy over the rest of the argument list.
      * gram_gatekeeper will have placed the path to the job_manager
-	 * as arg[1]. 
+     * as arg[1].
      */
 
     for (i = 1; i<argc; i++) {
@@ -344,22 +343,22 @@ main(int argc, char *argv[])
 
     cp = strrchr(newpath, '/');
     if (cp)
-      cp++;
+        cp++;
     else
-      cp = newpath;
+        cp = newpath;
 
     newargv[0] = cp;
 
-    DEEDEBUG2("calling the program %s \n",newpath);
+    DEEDEBUG2("calling the program %s \n", newpath);
 
 #ifdef DEBUG
-	/* fclose(stderrX); */
+    /* fclose(stderrX); */
 #endif
 
-      execv(newpath,newargv);
+    execv(newpath, newargv);
 
     /* only reachable if execl fails */
 
     fprintf(stderr, "Exec of %s failed: \n", newpath);
-        exit(1);
+    exit(1);
 }

--- a/gram/jobmanager/lrms/fork/source/configure.ac
+++ b/gram/jobmanager/lrms/fork/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gram_job_manager_fork],[3.2],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gram_job_manager_fork],[3.3],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gram/jobmanager/lrms/fork/source/seg/seg_fork_module.c
+++ b/gram/jobmanager/lrms/fork/source/seg/seg_fork_module.c
@@ -198,7 +198,7 @@ globus_l_fork_module_activate(void)
     int                                 rc;
     globus_reltime_t                    delay;
     globus_result_t                     result;
-    int                                 save_errno;
+
     GlobusFuncName(globus_l_fork_module_activate);
 
     rc = globus_module_activate(GLOBUS_COMMON_MODULE);
@@ -239,7 +239,6 @@ globus_l_fork_module_activate(void)
 
     if (logfile_state == NULL)
     {
-        save_errno = errno;
         SEGForkDebug(SEG_FORK_DEBUG_ERROR,
                 ("Fatal error: out of memory\n"));
         goto destroy_cond_error;
@@ -248,7 +247,6 @@ globus_l_fork_module_activate(void)
     rc = globus_l_fork_increase_buffer(logfile_state);
     if (rc != GLOBUS_SUCCESS)
     {
-        save_errno = errno;
         SEGForkDebug(SEG_FORK_DEBUG_ERROR,
                 ("Fatal error: out of memory\n"));
         goto free_logfile_state_error;
@@ -488,7 +486,7 @@ globus_l_fork_find_logfile(
 {
     struct stat                         s;
     int                                 rc;
-    int                                 save_errno;
+    int                                 save_errno = 0;
     GlobusFuncName(globus_l_fork_find_logfile);
 
     SEGForkEnter();

--- a/gram/jobmanager/lrms/sge/source/configure.ac
+++ b/gram/jobmanager/lrms/sge/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gram_job_manager_sge],[3.2],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gram_job_manager_sge],[3.3],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gram/jobmanager/lrms/sge/source/seg/seg_sge_module.c
+++ b/gram/jobmanager/lrms/sge/source/seg/seg_sge_module.c
@@ -7,12 +7,13 @@
 
 /* This #define is needed for the correct operation of the GLIBC strptime
  * function. */
-#define _XOPEN_SOURCE 1
+#define _XOPEN_SOURCE 600
 
 #include "globus_common.h"
 #include "globus_scheduler_event_generator.h"
 #include "version.h"
 
+#include <stdlib.h>
 #include <string.h>
 
 #define SEG_SGE_DEBUG(level, message) \
@@ -483,7 +484,6 @@ free_sge_cell:
     {
         free(sge_cell);
     }
-free_sge_root:
     if (sge_root != NULL)
     {
         free(sge_root);

--- a/gram/jobmanager/scheduler_event_generator/source/configure.ac
+++ b/gram/jobmanager/scheduler_event_generator/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_scheduler_event_generator],[6.4],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_scheduler_event_generator],[6.5],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gram/jobmanager/scheduler_event_generator/source/test/globus_scheduler_event_generator_stdout.c
+++ b/gram/jobmanager/scheduler_event_generator/source/test/globus_scheduler_event_generator_stdout.c
@@ -69,7 +69,7 @@ static globus_xio_handle_t              globus_l_seg_output_handle;
 static globus_xio_handle_t              globus_l_seg_input_handle;
 static globus_xio_stack_t               globus_l_seg_file_stack;
 static globus_xio_driver_t              globus_l_seg_file_driver;
-static char                             globus_l_seg_input_buffer[1];
+static globus_byte_t                    globus_l_seg_input_buffer[1];
 static time_t                           globus_l_seg_timestamp;
 static globus_fifo_t                    globus_l_seg_buffers;
 static globus_bool_t                    globus_l_seg_write_registered;
@@ -390,7 +390,7 @@ globus_l_stdout_scheduler_event(
     ...)
 {
     globus_result_t                     result = GLOBUS_SUCCESS;
-    char *                              buf;
+    globus_byte_t *                     buf;
     va_list                             ap;
     int                                 length;
 
@@ -421,7 +421,7 @@ globus_l_stdout_scheduler_event(
     }
 
     va_start(ap, format);
-    vsprintf(buf, format, ap);
+    vsprintf((char *)buf, format, ap);
     va_end(ap);
 
     globus_mutex_lock(&globus_l_seg_mutex);

--- a/gram/jobmanager/scheduler_event_generator/source/test/globus_scheduler_event_generator_stdout.h
+++ b/gram/jobmanager/scheduler_event_generator/source/test/globus_scheduler_event_generator_stdout.h
@@ -32,7 +32,7 @@ extern
 globus_result_t
 globus_scheduler_event_generator_stdout_handler(
     void *                              arg,
-    globus_scheduler_event_t *          event);
+    const globus_scheduler_event_t *    event);
 
 #ifdef __cplusplus
 }

--- a/gram/jobmanager/source/configure.ac
+++ b/gram/jobmanager/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gram_job_manager],[15.7],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gram_job_manager],[15.8],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gram/jobmanager/source/globus_gram_job_manager.c
+++ b/gram/jobmanager/source/globus_gram_job_manager.c
@@ -1041,6 +1041,7 @@ globus_l_gram_job_manager_remove_reference_locked(
     int                                 rc = GLOBUS_SUCCESS;
 
     strncpy(gramid, key, sizeof(gramid));
+    gramid[sizeof(gramid) - 1] = '\0';
     ref = globus_hashtable_lookup(&manager->request_hash, (void *) key);
     if (ref)
     {
@@ -1246,7 +1247,7 @@ globus_gram_job_manager_register_job_id(
     globus_bool_t                       prelocked)
 {
     int                                 rc = GLOBUS_SUCCESS;
-    globus_gram_job_id_ref_t *          ref;
+    globus_gram_job_id_ref_t *          ref = NULL;
     globus_gram_job_id_ref_t *          old_ref;
     globus_list_t                       *subjobs = NULL, *tmp_list;
     char *                              subjob_id;
@@ -1478,7 +1479,7 @@ globus_gram_job_manager_register_job_id(
             request->job_contact_path,
             0);
 
-    if (rc != GLOBUS_SUCCESS)
+    if (ref && rc != GLOBUS_SUCCESS)
     {
 hash_insert_failed:
         free(ref->job_contact_path);

--- a/gram/jobmanager/source/globus_gram_job_manager_config.c
+++ b/gram/jobmanager/source/globus_gram_job_manager_config.c
@@ -61,7 +61,6 @@ globus_gram_job_manager_config_init(
 {
     int                                 i;
     int                                 rc = 0;
-    char *                              tmp;
     char                                hostname[MAXHOSTNAMELEN];
     struct utsname                      utsname;
     char *                              conf_path = NULL;

--- a/gram/jobmanager/source/globus_gram_job_manager_request.c
+++ b/gram/jobmanager/source/globus_gram_job_manager_request.c
@@ -114,12 +114,6 @@ globus_l_gram_make_job_dir(
     char **                             job_directory);
 
 static
-int
-globus_l_gram_check_position(
-    globus_gram_jobmanager_request_t *  request,
-    globus_rsl_t *                      position_rsl);
-
-static
 void
 globus_l_gram_event_destroy(void *datum);
 
@@ -3947,77 +3941,6 @@ out:
     return rc;
 }
 /* globus_l_gram_make_job_dir() */
-
-/**
- * Check that all stdout_position or stderr_values are 0
- *
- * @retval GLOBUS_SUCCESS
- *     Success
- * @retval GLOBUS_GRAM_PROTOCOL_ERROR_INVALID_STDOUT_POSITION
- *     Invalid stdout_position
- * @retval GLOBUS_GRAM_PROTOCOL_ERROR_INVALID_STDERR_POSITION
- *     Invalid stderr_position
- */
-static
-int
-globus_l_gram_check_position(
-    globus_gram_jobmanager_request_t *  request,
-    globus_rsl_t *                      position_rsl)
-{
-    int                                 rc = GLOBUS_SUCCESS;
-    globus_rsl_value_t *                value_seq;
-    globus_list_t *                     values;
-    const char *                        value_string;
-    long                                longval;
-    char                                charval;
-
-    value_seq = globus_rsl_relation_get_value_sequence(position_rsl);
-
-    if (value_seq == NULL)
-    {
-        rc = GLOBUS_GRAM_PROTOCOL_ERROR_BAD_RSL;
-        goto non_sequence;
-    }
-
-    values = globus_rsl_value_sequence_get_value_list(value_seq);
-    while (!globus_list_empty(values))
-    {
-        value_string = globus_rsl_value_literal_get_string(
-                globus_list_first(values));
-        values = globus_list_rest(values);
-        if (value_string == NULL)
-        {
-            rc = GLOBUS_GRAM_PROTOCOL_ERROR_BAD_RSL;
-            goto non_literal;
-        }
-
-        errno = 0;
-        if (scanf("%ld%c", &longval, &charval) != 1)
-        {
-            rc = GLOBUS_GRAM_PROTOCOL_ERROR_BAD_RSL;
-            goto non_zero;
-        }
-
-    }
-non_zero:
-non_literal:
-non_sequence:
-    if (rc != GLOBUS_SUCCESS)
-    {
-        if (strcmp(
-                    globus_rsl_relation_get_attribute(position_rsl),
-                    "stdoutposition") == 0)
-        {
-            rc = GLOBUS_GRAM_PROTOCOL_ERROR_INVALID_STDOUT_POSITION;
-        }
-        else
-        {
-            rc = GLOBUS_GRAM_PROTOCOL_ERROR_INVALID_STDERR_POSITION;
-        }
-    }
-    return rc;
-}
-/* globus_l_gram_check_position() */
 
 static
 void

--- a/gram/jobmanager/source/globus_gram_job_manager_seg.c
+++ b/gram/jobmanager/source/globus_gram_job_manager_seg.c
@@ -1157,15 +1157,15 @@ globus_l_condor_parse_log(
 {
     regmatch_t                          matches[8];
     const char *                        p;
-    int                                 event_type_number;
+    int                                 event_type_number = 0;
     const char *                        event_time;
-    int                                 cluster;
-    int                                 proc;
-    int                                 subproc;
-    globus_bool_t                       terminated_normally;
+    int                                 cluster = 0;
+    int                                 proc = 0;
+    int                                 subproc = 0;
+    globus_bool_t                       terminated_normally = GLOBUS_FALSE;
     int                                 return_value = 0;
     struct tm                           event_tm;
-    time_t                              event_stamp;
+    time_t                              event_stamp = 0;
     int                                 rc;
     globus_off_t                        parsed_length = 0;
     globus_scheduler_event_t *          event;

--- a/gram/jobmanager/source/globus_gram_job_manager_staging.c
+++ b/gram/jobmanager/source/globus_gram_job_manager_staging.c
@@ -367,7 +367,6 @@ globus_l_staging_replace_stream(
 {
     globus_list_t *                     list;
     globus_rsl_value_t                  *to;
-    globus_rsl_value_t                  from_cached;
     globus_bool_t                       single;
     int                                 rc = GLOBUS_SUCCESS;
 
@@ -382,8 +381,6 @@ globus_l_staging_replace_stream(
          */
         return GLOBUS_SUCCESS;
     }
-    from_cached.type = GLOBUS_RSL_VALUE_LITERAL;
-    from_cached.value.literal.string = cached_destination;
 
     /* The stdout and stderr attributes can occur in two forms:
      * - stdout = destination [tag]
@@ -479,7 +476,7 @@ globus_gram_job_manager_staging_remove(
                                         query;
     globus_gram_job_manager_staging_info_t *
                                         item;
-    globus_list_t **                    list;
+    globus_list_t **                    list = NULL;
     globus_list_t *                     node;
     const char *                        typestr = "";
 

--- a/gram/jobmanager/source/globus_gram_job_manager_state.c
+++ b/gram/jobmanager/source/globus_gram_job_manager_state.c
@@ -154,8 +154,6 @@ globus_l_gram_job_manager_state_machine(
     globus_bool_t                       event_registered = GLOBUS_FALSE;
     globus_reltime_t                    delay_time;
     int                                 rc = 0;
-    int                                 save_status;
-    int                                 save_jobmanager_state;
     globus_gram_job_manager_query_t *   query;
     globus_bool_t                       first_poll = GLOBUS_FALSE;
     globus_gram_jobmanager_state_t      next_state;
@@ -690,8 +688,6 @@ globus_l_gram_job_manager_state_machine(
             request->jobmanager_state =
                 GLOBUS_GRAM_JOB_MANAGER_STATE_FAILED_CLOSE_OUTPUT;
         }
-        save_status = request->status;
-        save_jobmanager_state = request->jobmanager_state;
 
         /* Reply to any outstanding queries */
         while (!globus_fifo_empty(&request->pending_queries))
@@ -1102,7 +1098,7 @@ globus_gram_job_manager_reply(
     globus_size_t                       replysize;
     globus_byte_t *                     sendbuf;
     globus_size_t                       sendsize;
-    OM_uint32                           major_status;
+    OM_uint32                           major_status = GSS_S_COMPLETE;
     OM_uint32                           minor_status;
     int                                 token_status;
     globus_hashtable_t                  extensions = NULL;
@@ -1748,6 +1744,8 @@ globus_l_gram_job_manager_set_restart_state(
         request->unsent_status_change = GLOBUS_TRUE;
         request->jobmanager_state = GLOBUS_GRAM_JOB_MANAGER_STATE_POLL1;
         changed = GLOBUS_TRUE;
+        break;
+      default:
         break;
     }
     /*request->restart_state = GLOBUS_GRAM_JOB_MANAGER_STATE_START;*/

--- a/gram/jobmanager/source/logging.c
+++ b/gram/jobmanager/source/logging.c
@@ -55,8 +55,6 @@ globus_gram_job_manager_logging_init(
     globus_gram_job_manager_config_t *  config)
 {
     globus_result_t                     result = GLOBUS_SUCCESS;
-    time_t                              now;
-    struct tm *                         nowtm;
     int                                 rc;
 
     if (config->syslog_enabled)
@@ -112,8 +110,6 @@ globus_gram_job_manager_logging_init(
 
     globus_l_gram_logging_module.header_func =
             globus_logging_stdio_ng_module.header_func;
-    now = time(NULL);
-    nowtm = gmtime(&now);
 
     result = globus_logging_init(
             &globus_i_gram_job_manager_log_stdio,

--- a/gram/jobmanager/source/main.c
+++ b/gram/jobmanager/source/main.c
@@ -906,6 +906,7 @@ globus_l_gram_process_pending_restarts(
         key = globus_list_first(manager->pending_restarts);
         globus_assert(key != NULL);
         strncpy(gramid, key, sizeof(gramid));
+        gramid[sizeof(gramid) - 1] = '\0';
 
         GlobusGramJobManagerUnlock(manager);
 

--- a/gram/jobmanager/source/startup_socket.c
+++ b/gram/jobmanager/source/startup_socket.c
@@ -1352,6 +1352,7 @@ globus_l_gram_startup_socket_callback(
             goto failed_receive;
         }
 
+        sent_fds = NULL;
         for (control_message = CMSG_FIRSTHDR(&message);
              control_message != NULL;
              control_message = CMSG_NXTHDR(&message, control_message))
@@ -1363,6 +1364,13 @@ globus_l_gram_startup_socket_callback(
                 break;
             }
         }
+
+        if (!sent_fds)
+        {
+            rc = GLOBUS_GRAM_PROTOCOL_ERROR_PROTOCOL_FAILED;
+            goto failed_receive;
+        }
+
         message_length  = message_length_buffer[0] << 24;
         message_length += message_length_buffer[1] << 16;
         message_length += message_length_buffer[2] << 8;

--- a/gram/jobmanager/source/test/client/restart-to-new-url-test.c
+++ b/gram/jobmanager/source/test/client/restart-to-new-url-test.c
@@ -434,7 +434,6 @@ test_restart_to_new_url(void)
         test_assert(monitor.old_output[0] == 0);
     }
 
-done:
     return rc;
 }
 /* test_restart_to_new_url() */

--- a/gram/jobmanager/source/test/client/stdio-update-after-failure-test.c
+++ b/gram/jobmanager/source/test/client/stdio-update-after-failure-test.c
@@ -294,10 +294,6 @@ int main(int argc, char *argv[])
             &ignore_failure_code);
     fprintf(stderr, "commit request result %d\n", rc);
 
-commit_end_failed:
-incorrect_size_error:
-still_streaming_check_failed2:
-still_streaming_check_failed:
 unexpected_job_state:
 commit_request_failed:
     if (monitor.job_contact != NULL)

--- a/gridftp/client/source/configure.ac
+++ b/gridftp/client/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_ftp_client],[9.7],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_ftp_client],[9.8],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gridftp/client/source/globus_ftp_client_attr.c
+++ b/gridftp/client/source/globus_ftp_client_attr.c
@@ -181,7 +181,7 @@ globus_l_ftp_base64_encode(
 {
     int                                 i;
     int                                 j;
-    unsigned char                       c;
+    unsigned char                       c = 0;
 
     for (i=0,j=0; i < in_len; i++)
     {

--- a/gridftp/client/source/globus_ftp_client_perf_plugin.c
+++ b/gridftp/client/source/globus_ftp_client_perf_plugin.c
@@ -178,7 +178,7 @@ perf_plugin_response_cb(
     char *                                      tmp_ptr;
     int                                         count;
     long                                        time_stamp_int;
-    char                                        time_stamp_tenght;
+    char                                        time_stamp_tenth;
     int                                         stripe_ndx;
     int                                         num_stripes;
     globus_off_t                                nbytes;
@@ -214,11 +214,11 @@ perf_plugin_response_cb(
             tmp_ptr++;
         }
 
-        time_stamp_tenght = 0;
+        time_stamp_tenth = 0;
         if(*tmp_ptr == '.')
         {
             tmp_ptr++;
-            time_stamp_tenght = *tmp_ptr - '0';
+            time_stamp_tenth = *tmp_ptr - '0';
             tmp_ptr++;
         }
 
@@ -271,7 +271,7 @@ perf_plugin_response_cb(
             ps->user_specific,
             handle,
             time_stamp_int,
-            time_stamp_tenght,
+            time_stamp_tenth,
             stripe_ndx,
             num_stripes,
             nbytes);

--- a/gridftp/client/source/globus_ftp_client_perf_plugin.h
+++ b/gridftp/client/source/globus_ftp_client_perf_plugin.h
@@ -112,8 +112,11 @@ typedef void (*globus_ftp_client_perf_plugin_begin_cb_t)(
  *        or, if a copy method was not specified, the value passed to
  *        init
  *
- * @param time_stamp
- *        the timestamp at which the number of bytes is valid
+ * @param time_stamp_int
+ *        the timestamp at which the number of bytes is valid (integer part)
+ *
+ * @param time_stamp_tenth
+ *        the timestamp at which the number of bytes is valid (tenth part)
  *
  * @param stripe_ndx
  *        the stripe index this data refers to
@@ -131,7 +134,7 @@ typedef void (*globus_ftp_client_perf_plugin_marker_cb_t)(
     void *                                          user_specific,
     globus_ftp_client_handle_t *                    handle,
     long                                            time_stamp_int,
-    char                                            time_stamp_tength,
+    char                                            time_stamp_tenth,
     int                                             stripe_ndx,
     int                                             num_stripes,
     globus_off_t                                    nbytes);

--- a/gridftp/client/source/globus_ftp_client_plugin.h
+++ b/gridftp/client/source/globus_ftp_client_plugin.h
@@ -168,6 +168,8 @@ typedef void (*globus_ftp_client_plugin_destroy_t)(
  *        Plugin-specific data.
  * @param handle
  *        The handle associated with the connection.
+ * @param url
+ *        The URL of the server to connect to.
  *
  * @note This function will not be called for a get, put, or
  * third-party transfer operation when a cached connection is used.
@@ -358,7 +360,7 @@ typedef void (*globus_ftp_client_plugin_symlink_t)(
     void *                  plugin_specific,
     globus_ftp_client_handle_t *        handle,
     const char *                url,
-    const char *                utime_time,
+    const char *                link_url,
     const globus_ftp_client_operationattr_t *   attr,
     globus_bool_t               restart);
 
@@ -1076,6 +1078,9 @@ typedef void (*globus_ftp_client_plugin_write_t)(
  *        Plugin-specific data.
  * @param handle
  *        The handle associated with the request.
+ * @param error
+ *        An error which occurred while processing this
+ *        command/response pair.
  * @param buffer
  *        The buffer which was successfully transferred over the network.
  * @param length
@@ -1147,7 +1152,7 @@ typedef void (*globus_ftp_client_plugin_command_t)(
  *        The URL which this response came from.
  * @param error
  *        An error which occurred while processing this
- *	  command/response pair.
+ *        command/response pair.
  * @param ftp_response
  *        The response structure from the ftp control library.
  */

--- a/gridftp/client/source/globus_ftp_client_throughput_plugin.c
+++ b/gridftp/client/source/globus_ftp_client_throughput_plugin.c
@@ -158,7 +158,7 @@ throughput_plugin_marker_cb(
     void *                                      user_specific,
     globus_ftp_client_handle_t *                handle,
     long                                        time_stamp_int,
-    char                                        time_stamp_tength,
+    char                                        time_stamp_tenth,
     int                                         stripe_ndx,
     int                                         num_stripes,
     globus_off_t                                nbytes)
@@ -173,7 +173,7 @@ throughput_plugin_marker_cb(
 
     info = (throughput_plugin_info_t *) user_specific;
 
-    time_stamp = time_stamp_int + (time_stamp_tength / 10.0);
+    time_stamp = time_stamp_int + (time_stamp_tenth / 10.0);
 
     /* init prev and cur storage if not already done so */
     if(info->prev_times == GLOBUS_NULL)

--- a/gridftp/client/source/test/chgrp-test.c
+++ b/gridftp/client/source/test/chgrp-test.c
@@ -57,7 +57,7 @@ int main(int argc, char * argv[])
     globus_ftp_client_handleattr_t      handle_attr;
     char *                  src = NULL;
     char *                  dst = NULL;
-    char *                                      group;
+    char *                                      group = NULL;
     extern char *                               optarg;
     extern int                                  optind;
     int                                         c;

--- a/gridftp/client/source/test/chmod-test.c
+++ b/gridftp/client/source/test/chmod-test.c
@@ -57,7 +57,7 @@ int main(int argc, char * argv[])
     globus_ftp_client_handleattr_t		handle_attr;
     char *					src = NULL;
     char *					dst = NULL;
-    int                                         mode;
+    int                                         mode = 0;
     extern char *                               optarg;
     extern int                                  optind;
     int                                         c;

--- a/gridftp/client/source/test/cksm-test.c
+++ b/gridftp/client/source/test/cksm-test.c
@@ -24,7 +24,6 @@ static globus_mutex_t lock;
 static globus_cond_t cond;
 static globus_bool_t done;
 static globus_bool_t error = GLOBUS_FALSE;
-#define SIZE 42
 
 static
 void
@@ -55,8 +54,6 @@ int main(int argc,
     globus_ftp_client_handle_t			handle;
     globus_ftp_client_operationattr_t 		attr;
     globus_ftp_client_handleattr_t		handle_attr;
-    globus_byte_t				buffer[SIZE];
-    globus_size_t				buffer_length = sizeof(buffer);
     globus_result_t				result;
     char *				        cksm;
     char *					src;

--- a/gridftp/client/source/test/exist-test.c
+++ b/gridftp/client/source/test/exist-test.c
@@ -24,7 +24,6 @@ static globus_mutex_t lock;
 static globus_cond_t cond;
 static globus_bool_t done;
 static globus_bool_t error = GLOBUS_FALSE;
-#define SIZE 42
 
 static
 void
@@ -55,8 +54,6 @@ int main(int argc,
     globus_ftp_client_handle_t			handle;
     globus_ftp_client_operationattr_t 		attr;
     globus_ftp_client_handleattr_t		handle_attr;
-    globus_byte_t				buffer[SIZE];
-    globus_size_t				buffer_length = sizeof(buffer);
     globus_result_t				result;
     char *					src;
     char *					dst;

--- a/gridftp/client/source/test/globus_ftp_client_test_pause_plugin.c
+++ b/gridftp/client/source/test/globus_ftp_client_test_pause_plugin.c
@@ -180,17 +180,6 @@ globus_l_ftp_client_test_pause_plugin_put(
 
 static
 void
-globus_l_ftp_client_test_pause_plugin_command(
-    globus_ftp_client_plugin_t *			plugin,
-    void *						plugin_specific,
-    globus_ftp_client_handle_t *			handle,
-    const char *					url,
-    const char *					command_name)
-{
-}
-
-static
-void
 globus_l_ftp_client_test_pause_plugin_response(
     globus_ftp_client_plugin_t *			plugin,
     void *						plugin_specific,
@@ -263,7 +252,6 @@ globus_ftp_client_test_pause_plugin_init(
     globus_result_t					result;
     globus_object_t *					err;
     int *						plugin_specific;
-    static char * myname = "globus_ftp_client_test_pause_plugin_init";
 
     plugin_specific = globus_libc_malloc(sizeof(int));
     result = globus_ftp_client_plugin_init(

--- a/gridftp/client/source/test/globus_ftp_client_test_perf_plugin.c
+++ b/gridftp/client/source/test/globus_ftp_client_test_perf_plugin.c
@@ -61,13 +61,13 @@ void perf_plugin_marker_cb(
     void *                                          user_specific,
     globus_ftp_client_handle_t *                    handle,
     long                                            time_stamp_int,
-    char                                            time_stamp_tength,
+    char                                            time_stamp_tenth,
     int                                             stripe_ndx,
     int                                             num_stripes,
     globus_off_t                                    nbytes)
 {
     globus_libc_fprintf(stderr, "perf_plugin_marker_cb\n");
-    globus_libc_fprintf(stderr, "time_stamp   %ld.%d\n", time_stamp_int, time_stamp_tength);
+    globus_libc_fprintf(stderr, "time_stamp   %ld.%d\n", time_stamp_int, time_stamp_tenth);
     globus_libc_fprintf(stderr, "stripe_ndx   %d\n", stripe_ndx);
     globus_libc_fprintf(stderr, "num_stripes  %d\n", num_stripes);
     globus_libc_fprintf(stderr, "nbytes       %" GLOBUS_OFF_T_FORMAT "\n", nbytes);

--- a/gridftp/client/source/test/globus_ftp_client_test_restart_plugin.c
+++ b/gridftp/client/source/test/globus_ftp_client_test_restart_plugin.c
@@ -106,7 +106,7 @@ globus_bool_t
 globus_l_ftp_client_test_restart_plugin_activate(void)
 {
     char *                              rangecnt;
-    if(rangecnt = getenv("FTP_TEST_RESTART_AFTER_RANGE"))
+    if((rangecnt = getenv("FTP_TEST_RESTART_AFTER_RANGE")))
     {
         globus_l_ftp_client_test_restart_range = atoi(rangecnt);
         if(globus_l_ftp_client_test_restart_range < 0)
@@ -877,8 +877,8 @@ globus_l_ftp_client_test_restart_plugin_response(
     d = plugin_specific;
     if(response->code == 111 &&
         globus_l_ftp_client_test_restart_range > 0 &&
-        d->when == FTP_RESTART_AT_STOR_RESPONSE || 
-        d->when == FTP_RESTART_AT_RETR_RESPONSE)
+        (d->when == FTP_RESTART_AT_STOR_RESPONSE ||
+         d->when == FTP_RESTART_AT_RETR_RESPONSE))
     {
         if(--globus_l_ftp_client_test_restart_range == 0)
         {
@@ -1054,37 +1054,6 @@ globus_l_ftp_client_test_restart_plugin_fault(
 {
     fprintf(stderr,"[restart plugin]: Fault detected\n");
 }
-
-static
-void 
-globus_l_ftp_client_test_restart_plugin_complete(
-    globus_ftp_client_plugin_t *		plugin,
-    void *						plugin_specific,
-    globus_ftp_client_handle_t *		handle)
-{
-    globus_l_ftp_restart_plugin_specific_t *	d;
-
-    fprintf(stderr,"[restart plugin]: operation completed\n");
-
-    d = plugin_specific;
-
-    if(d->source_url)
-    {
-	globus_libc_free(d->source_url);
-        globus_ftp_client_operationattr_destroy(&d->source_attr);
-    }
-    if(d->dest_url)
-    {
-	globus_libc_free(d->dest_url);
-        globus_ftp_client_operationattr_destroy(&d->dest_attr);
-    }
-    if (d->chgrp_group) 
-    {
-        globus_libc_free(d->chgrp_group);
-        d->chgrp_group = GLOBUS_NULL;
-    }
- }
-
 
 globus_result_t
 globus_ftp_client_test_restart_plugin_init(

--- a/gridftp/client/source/test/lingering-get-test.c
+++ b/gridftp/client/source/test/lingering-get-test.c
@@ -23,6 +23,7 @@
  * deactivation.
  */
 #include "globus_ftp_client.h"
+#include "globus_ftp_client_test_common.h"
 #include "globus_preload.h"
 
 static globus_mutex_t lock;
@@ -54,8 +55,6 @@ int main(int argc,
 {
     globus_ftp_client_handle_t			handle;
     globus_ftp_client_operationattr_t		attr;
-    globus_byte_t				buffer[1024];
-    globus_size_t				buffer_length = sizeof(buffer);
     globus_result_t				result;
     char *					src;
     char *					dst;

--- a/gridftp/client/source/test/modification-time-test.c
+++ b/gridftp/client/source/test/modification-time-test.c
@@ -24,7 +24,6 @@ static globus_mutex_t lock;
 static globus_cond_t cond;
 static globus_bool_t done;
 static globus_bool_t error = GLOBUS_FALSE;
-#define SIZE 42
 
 static
 void
@@ -55,12 +54,9 @@ int main(int argc,
     globus_ftp_client_handle_t			handle;
     globus_ftp_client_operationattr_t 		attr;
     globus_ftp_client_handleattr_t		handle_attr;
-    globus_byte_t				buffer[SIZE];
-    globus_size_t				buffer_length = sizeof(buffer);
     globus_result_t				result;
     globus_abstime_t				modification_time;
     time_t					t;
-    struct tm *					tm;
     char *					src;
     char *					dst;
 

--- a/gridftp/client/source/test/multiget-test.c
+++ b/gridftp/client/source/test/multiget-test.c
@@ -42,7 +42,7 @@ done_cb(
 	globus_object_t *			err)
 {
     char * tmpstr;
-    int iterations_left;
+    long iterations_left;
 
     if(err)
     {
@@ -88,9 +88,8 @@ globus_ftp_client_handleattr_t		handle_attr;
 int main(int argc, char *argv[])
 {
     globus_ftp_client_handle_t *		handles;
-    globus_result_t				result;
     int						num_handles = 0;
-    int						num_iterations = 0;
+    long					num_iterations = 0;
     char *					dst;
     int						i;
     globus_bool_t				caching = GLOBUS_FALSE;
@@ -105,7 +104,7 @@ int main(int argc, char *argv[])
 	}
 	if(strcmp(argv[i], "-I") == 0 && i + 1 < argc)
 	{
-	    num_iterations = atoi(argv[i+1]);
+	    num_iterations = atol(argv[i+1]);
 
 	    test_remove_arg(&argc, argv, &i, 1);
 	}
@@ -176,7 +175,7 @@ static void
 register_get(globus_ftp_client_handle_t *	handle)
 {
     globus_byte_t *				buffer;
-    int						iterations_left;
+    long					iterations_left;
     globus_result_t				result;
 
     globus_ftp_client_handle_get_user_pointer(handle,

--- a/gridftp/client/source/test/multiple-block-put-test.c
+++ b/gridftp/client/source/test/multiple-block-put-test.c
@@ -64,8 +64,8 @@ data_cb(
     globus_result_t				result;
     static int					once = 0;
     if(eof || err) {
-    printf("Data callback: %d bytes, %s %s\n", length, eof?"eof":"not eof",
-	    err?"error":"no error");
+	printf("Data callback: %zd bytes, %s %s\n", length,
+	       eof ? "eof" : "not eof", err ? "error" : "no error");
     }
     /*fwrite(buffer, 1, length, stdout);*/
     if(!eof && !once)

--- a/gridftp/client/source/test/size-test.c
+++ b/gridftp/client/source/test/size-test.c
@@ -24,7 +24,6 @@ static globus_mutex_t lock;
 static globus_cond_t cond;
 static globus_bool_t done;
 static globus_bool_t error = GLOBUS_FALSE;
-#define SIZE 42
 
 static
 void
@@ -55,8 +54,6 @@ int main(int argc,
     globus_ftp_client_handle_t			handle;
     globus_ftp_client_operationattr_t 		attr;
     globus_ftp_client_handleattr_t		handle_attr;
-    globus_byte_t				buffer[SIZE];
-    globus_size_t				buffer_length = sizeof(buffer);
     globus_result_t				result;
     globus_off_t				size;
     char *					src;

--- a/gridftp/control/source/configure.ac
+++ b/gridftp/control/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_ftp_control], [9.8], [https://github.com/gridcf/gct/issues])
+AC_INIT([globus_ftp_control], [9.9], [https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gridftp/control/source/globus_ftp_control.h
+++ b/gridftp/control/source/globus_ftp_control.h
@@ -568,21 +568,21 @@ typedef void
  *  @param handle
  *         The control handle that the command was issued on.
  *  @param error
- *         Indicates if a command was successful read or
+ *         Indicates if a command was successfully read or
  *         or if a failure occurred. This object will be freed once
- *	   this callback returns. If the user wishes to have a copy
- *	   of the error that persists past the life of this callback,
- *	   they must make a copy using globus_object_copy(), and free
- *	   it with globus_object_free().
+ *         this callback returns. If the user wishes to have a copy
+ *         of the error that persists past the life of this callback,
+ *         they must make a copy using globus_object_copy(), and free
+ *         it with globus_object_free().
  *  @param command
  *         The command structure indicates what type of command the
  *         client issued.  Based on the 'type' further information
  *         can be extracted. This command structure will be freed once
- *	   this callback returns. If the user wishes to have a copy
- *	   of the error that persists past the life of this callback,
- *	   they must make a copy using
+ *         this callback returns. If the user wishes to have a copy
+ *         of the error that persists past the life of this callback,
+ *         they must make a copy using
  *         globus_ftp_control_command_copy(), and free
- *	   it with globus_ftp_control_command_free().
+ *         it with globus_ftp_control_command_free().
  */
 typedef void (*globus_ftp_control_command_callback_t)(
     void *                                   callback_arg,
@@ -603,6 +603,13 @@ typedef void (*globus_ftp_control_command_callback_t)(
  *  @param handle
  *         This structure is populated when the callback is called and
  *         represents a control connection to the client.
+ *  @param error
+ *         Indicates if a command was successfully read or
+ *         or if a failure occurred. This object will be freed once
+ *         this callback returns. If the user wishes to have a copy
+ *         of the error that persists past the life of this callback,
+ *         they must make a copy using globus_object_copy(), and free
+ *         it with globus_object_free().
  *  @param auth_result
  *         A globus_ftp_control_auth_result_t containing the
  *         values the client sent for gss authentication, user name,
@@ -1012,7 +1019,7 @@ struct globus_ftp_control_server_s;
  *
  * @param server_handle
  *        The server handle associated with callback.
- * @param result
+ * @param error
  *        Indicates if the operation completed successfully or
  *        if a failure occurred.
  * @param callback_arg

--- a/gridftp/control/source/globus_ftp_control_client.c
+++ b/gridftp/control/source/globus_ftp_control_client.c
@@ -2221,7 +2221,7 @@ globus_l_ftp_control_write_cb(
     globus_result_t                           rc;
     globus_ftp_control_rw_queue_element_t *   element;
     globus_bool_t                             write_queue_empty;
-    globus_bool_t                             read_queue_empty;
+    globus_bool_t                             read_queue_empty = GLOBUS_TRUE;
     globus_bool_t                             call_close_cb = GLOBUS_FALSE;
     
     globus_i_ftp_control_debug_printf(1,
@@ -4275,7 +4275,7 @@ globus_i_ftp_control_radix_encode(
 {
     int                                    i;
     int                                    j;
-    unsigned char                          c;
+    unsigned char                          c = 0;
     
     for (i=0,j=0; i < *length; i++)
     {
@@ -4344,7 +4344,7 @@ globus_i_ftp_control_radix_decode(
 {
     int                                    i;
     int                                    j;
-    int                                    D;
+    int                                    D = 0;
     char *                                 p;
 
     for (i=0,j=0; inbuf[i] && inbuf[i] != pad; i++) 

--- a/gridftp/control/source/globus_ftp_control_data.c
+++ b/gridftp/control/source/globus_ftp_control_data.c
@@ -4510,7 +4510,6 @@ globus_ftp_control_data_write(
     globus_i_ftp_dc_handle_t *                  dc_handle;
     globus_result_t                             result = GLOBUS_SUCCESS;
     globus_object_t *                           err;
-    globus_i_ftp_dc_transfer_handle_t *         transfer_handle;
     static char *                               myname=
                                       "globus_ftp_control_data_write";
 
@@ -4560,8 +4559,6 @@ globus_ftp_control_data_write(
                   myname);
         return globus_error_put(err);
     }
-
-    transfer_handle = dc_handle->transfer_handle;
 
     globus_mutex_lock(&dc_handle->mutex);
     {
@@ -4710,7 +4707,7 @@ globus_ftp_control_data_read(
     void *					callback_arg)
 {
     globus_i_ftp_dc_handle_t *                  dc_handle;
-    globus_result_t                             result;
+    globus_result_t                             result = GLOBUS_SUCCESS;
     globus_object_t *                           err;
     static char *                               myname=
                                       "globus_ftp_control_data_read";
@@ -5077,10 +5074,6 @@ globus_l_ftp_control_deactivate_quit_callback(
     globus_ftp_control_handle_t *               handle,
     globus_object_t *                           error)
 {
-    globus_i_ftp_dc_transfer_handle_t *         transfer_handle;
-
-    transfer_handle = (globus_i_ftp_dc_transfer_handle_t *)user_arg;
-
     globus_mutex_lock(&globus_l_ftp_control_data_mutex);
     {
         globus_l_ftp_control_data_dc_count--;
@@ -7654,13 +7647,11 @@ globus_l_ftp_control_reuse_connect_callback(
 {
     globus_l_ftp_dc_connect_cb_info_t *          connect_cb_info;
     globus_i_ftp_dc_handle_t *                   dc_handle;
-    globus_i_ftp_dc_transfer_handle_t *          transfer_handle;
 
     connect_cb_info = (globus_l_ftp_dc_connect_cb_info_t *)user_args;
 
     dc_handle = connect_cb_info->dc_handle;
     GlobusFTPControlDataTestMagic(dc_handle);
-    transfer_handle = connect_cb_info->transfer_handle;
 
     connect_cb_info->callback(
         connect_cb_info->user_arg,
@@ -7901,7 +7892,6 @@ globus_i_ftp_control_data_cc_destroy(
 {
     globus_i_ftp_dc_handle_t *                   dc_handle;
     globus_result_t                              res = GLOBUS_SUCCESS;
-    globus_bool_t                                destroy_it = GLOBUS_FALSE;
     globus_object_t *                            err;
 
     dc_handle = &control_handle->dc_handle;
@@ -7911,7 +7901,6 @@ globus_i_ftp_control_data_cc_destroy(
         if(dc_handle->state == GLOBUS_FTP_DATA_STATE_NONE)
         {
             dc_handle->initialized = GLOBUS_FALSE;
-            destroy_it = GLOBUS_TRUE;
             res = GLOBUS_SUCCESS;
 	        globus_io_tcpattr_destroy(&dc_handle->io_attr);
             if(dc_handle->nl_io_handle_set)
@@ -7973,7 +7962,6 @@ globus_ftp_control_data_force_close(
     globus_ftp_control_callback_t                close_callback_func,
     void *                                       close_arg)
 {
-    globus_i_ftp_dc_transfer_handle_t *          transfer_handle;
     globus_result_t                              res;
     globus_i_ftp_dc_handle_t *                   dc_handle;
     globus_object_t *                            err;
@@ -8024,8 +8012,6 @@ globus_ftp_control_data_force_close(
                       GLOBUS_NULL,
                 _FCSL("Handle not in the proper state")));
     }
-
-    transfer_handle = control_handle->dc_handle.transfer_handle;
 
     dc_handle = &control_handle->dc_handle;
     GlobusFTPControlDataTestMagic(dc_handle);
@@ -10212,7 +10198,7 @@ globus_l_ftp_eb_connect_callback(
     }
 
     /* this should only happen when there is an error */
-    if(eof_callback != GLOBUS_NULL)
+    if(eof_callback != GLOBUS_NULL && eof_cb_ent != GLOBUS_NULL)
     {
         eof_callback(
             eof_cb_ent->callback_arg,

--- a/gridftp/control/source/globus_ftp_control_server.c
+++ b/gridftp/control/source/globus_ftp_control_server.c
@@ -1308,7 +1308,6 @@ globus_ftp_control_server_authenticate(
         OM_uint32                       maj_stat = GSS_S_COMPLETE;
         OM_uint32                       min_stat = GSS_S_COMPLETE;
         OM_uint32                       ctx_flags = 0;
-        gss_name_t                      src_name = GSS_C_NO_NAME;
         gss_buffer_desc                 subject_buf = GSS_C_EMPTY_BUFFER;
 
         rc = globus_io_handle_get_xio_handle(
@@ -1403,7 +1402,7 @@ globus_ftp_control_server_authenticate(
             cc_handle->auth_info.auth_gssapi_subject,
             subject_buf.length + 1,
             "%s",
-            subject_buf.value);
+            (char*)subject_buf.value);
 
         gss_release_buffer(&min_stat, &subject_buf);
     }

--- a/gridftp/control/source/test/abort_test.c
+++ b/gridftp/control/source/test/abort_test.c
@@ -85,17 +85,17 @@ pasv_response_callback(
 
     if(ftp_response->code == 227)
     {
-verbose_printf(2, "pasv buffer :%s:\n", ftp_response->response_buffer);
-    pasv_to_host_port(ftp_response->response_buffer, &addr);
-verbose_printf(2, "pasv port %d.%d.%d.%d:%d\n", 
-      addr.host[0],
-      addr.host[1],
-      addr.host[2],
-      addr.host[3],
-      addr.port);
+        verbose_printf(2, "pasv buffer :%s:\n", ftp_response->response_buffer);
+        pasv_to_host_port((char *)ftp_response->response_buffer, &addr);
+        verbose_printf(2, "pasv port %d.%d.%d.%d:%d\n",
+            addr.host[0],
+            addr.host[1],
+            addr.host[2],
+            addr.host[3],
+            addr.port);
 
-    res = globus_ftp_control_local_port(handle, &addr);
-    test_result(res, "globus_ftp_control_local_port()");
+        res = globus_ftp_control_local_port(handle, &addr);
+        test_result(res, "globus_ftp_control_local_port()");
     }
     else
     {

--- a/gridftp/control/source/test/connect_test.c
+++ b/gridftp/control/source/test/connect_test.c
@@ -174,7 +174,6 @@ authenticate_clear(
     {
         .command = CMD_CONNECT,
     };
-    globus_ftp_control_auth_info_t      auth_info = {0};
     globus_xio_attr_t                   attr = NULL;
     globus_reltime_t                    timeout = {0};
     globus_result_t                     result = GLOBUS_SUCCESS;
@@ -243,7 +242,6 @@ authenticate_clear(
     globus_mutex_unlock(&test_client.mutex);
 
 connect_fail:
-use_tls_fail:
 auth_info_init_fail:
 xio_attr_cntl_fail:
 xio_attr_get_fail:
@@ -268,7 +266,6 @@ authenticate_gssapi(
     {
         .command = CMD_CONNECT,
     };
-    globus_ftp_control_auth_info_t      auth_info = {0};
     globus_xio_attr_t                   attr = NULL;
     globus_reltime_t                    timeout = {0};
     globus_result_t                     result = GLOBUS_SUCCESS;
@@ -338,7 +335,6 @@ authenticate_gssapi(
     }
     globus_mutex_unlock(&test_client.mutex);
 connect_fail:
-use_tls_fail:
 auth_info_init_fail:
 xio_attr_cntl_fail:
 xio_attr_get_fail:
@@ -363,7 +359,6 @@ authenticate_tls(
     {
         .command = CMD_CONNECT,
     };
-    globus_ftp_control_auth_info_t      auth_info = {0};
     globus_xio_attr_t                   attr = NULL;
     globus_reltime_t                    timeout = {0};
     globus_result_t                     result = GLOBUS_SUCCESS;
@@ -834,7 +829,6 @@ globus_l_server_auth_callback(
     globus_result_t                     res;
     char *                              username;
     globus_bool_t                       accepted;
-    char *                              tmp_ptr;
 
     if (error)
     {
@@ -1135,7 +1129,6 @@ failed_listen_cleartext:
         globus_io_tcpattr_destroy(&tls_server_attr);
     }
 failed_init_cleartext:
-failed_other_attr_init:
     return result;
 }
 /* initialize_servers() */

--- a/gridftp/control/source/test/data_test.c
+++ b/gridftp/control/source/test/data_test.c
@@ -1147,8 +1147,6 @@ connect_read_big_buffer_callback(
 
     globus_mutex_lock(&test_info->monitor->mutex);
     {
-        char                             sys_cmd[1024];
-
         copy_file(g_test_file, test_info->fname);
 
         test_info->fout = fopen(test_info->fname, "rb+");
@@ -1262,8 +1260,6 @@ data_read_big_buffer_callback(
         }
         else
         {
-            char                              sys_cmd[512];
-
             verbose_printf(3, "eof big buffer callback\n");
             /* write out the entire buffer */
             
@@ -1417,8 +1413,6 @@ data_read_callback(
 
         if(eof)
         {
-            char                              sys_cmd[512];
-
             verbose_printf(3, "closing the out stream\n");
             fclose(test_info->fout);
 
@@ -1558,9 +1552,7 @@ connect_write_zero_eof_callback(
     int                                        nbyte;
     globus_byte_t *                            buf;
     globus_bool_t                              eof = GLOBUS_FALSE;
-    globus_bool_t                              done = GLOBUS_FALSE;
     globus_result_t                            res;
-    int                                        ctr;
 
     test_info = (data_test_info_t *)callback_arg;
 

--- a/gridftp/control/source/test/eb_simple_data_test.c
+++ b/gridftp/control/source/test/eb_simple_data_test.c
@@ -401,7 +401,7 @@ eb_data_response_callback(
 
     if(ftp_response->code == 227)
     {
-        pasv_to_host_port(ftp_response->response_buffer, &addr);
+        pasv_to_host_port((char *)ftp_response->response_buffer, &addr);
         result = globus_ftp_control_local_port(handle, &addr);
         if(result != GLOBUS_SUCCESS)
         {

--- a/gridftp/control/source/test/outstanding_io_test.c
+++ b/gridftp/control/source/test/outstanding_io_test.c
@@ -327,7 +327,7 @@ outstanding_io_response_callback(
 
     if(ftp_response->code == 227)
     {
-        pasv_to_host_port(ftp_response->response_buffer, &addr);
+        pasv_to_host_port((char *)ftp_response->response_buffer, &addr);
         result = globus_ftp_control_local_port(handle, &addr);
         if(result != GLOBUS_SUCCESS)
         {

--- a/gridftp/control/source/test/pipe_test.c
+++ b/gridftp/control/source/test/pipe_test.c
@@ -182,8 +182,6 @@ read_command_cb(
     globus_object_t *                        error,
     union globus_ftp_control_command_u *     command)
 {
-    globus_bool_t                            queue_empty;
-
     if(error != GLOBUS_NULL)
     {
         globus_mutex_lock(&g_server_monitor.mutex);

--- a/gridftp/control/source/test/simple_data_test.c
+++ b/gridftp/control/source/test/simple_data_test.c
@@ -314,7 +314,7 @@ simple_data_response_callback(
 
     if(ftp_response->code == 227)
     {
-        pasv_to_host_port(ftp_response->response_buffer, &addr);
+        pasv_to_host_port((char *)ftp_response->response_buffer, &addr);
         result = globus_ftp_control_local_port(handle, &addr);
         if(result != GLOBUS_SUCCESS)
         {

--- a/gridftp/control/source/test/test_common.c
+++ b/gridftp/control/source/test/test_common.c
@@ -228,7 +228,6 @@ verbose_printf(
     char *                                    s, 
     ...)
 {
-    char                                     tmp[8192];
     va_list                                   ap;
 
     if(level > verbose_print_level)

--- a/gridftp/control/source/test/test_server.c
+++ b/gridftp/control/source/test/test_server.c
@@ -140,7 +140,6 @@ gpftpd_auth_callback(
     globus_result_t                          res;
     char *                                   username;
     globus_bool_t                            accepted;
-    char *                                   tmp_ptr;
 
     if(error)
     {

--- a/gridftp/gridftp_driver/source/configure.ac
+++ b/gridftp/gridftp_driver/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_xio_gridftp_driver],[3.5],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_xio_gridftp_driver],[3.6],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gridftp/gridftp_driver/source/globus_xio_gridftp_driver.c
+++ b/gridftp/gridftp_driver/source/globus_xio_gridftp_driver.c
@@ -737,7 +737,7 @@ globus_l_xio_gridftp_process_pending_ops(
 {
     globus_i_xio_gridftp_requestor_t *  requestor;
     globus_result_t                     result;
-    globus_i_xio_gridftp_error_info_t * error_info;
+    globus_i_xio_gridftp_error_info_t * error_info = NULL;
     globus_bool_t                       reading;
     GlobusXIOName(globus_l_xio_gridftp_process_pending_ops);
 
@@ -817,7 +817,7 @@ globus_l_xio_gridftp_process_pending_ops(
          * reporting. I use the error information stored in the error_list
          * for reporting it to the user.
          */
-        result = error_info->result;
+        result = error_info ? error_info->result : GLOBUS_FAILURE;
         goto error;
     }
     GlobusXIOGridftpDebugExit();
@@ -1044,10 +1044,10 @@ globus_l_xio_gridftp_write_cb(
 {
     globus_i_xio_gridftp_requestor_t *  requestor;
     globus_l_xio_gridftp_handle_t *     handle;
-    globus_xio_operation_t              requestor_op;
+    globus_xio_operation_t              requestor_op = NULL;
     globus_list_t *                     error_list = NULL;
-    globus_off_t                        requestor_offset;
-    globus_size_t                       requestor_length;
+    globus_off_t                        requestor_offset = 0;
+    globus_size_t                       requestor_length = 0;
     globus_result_t                     requestor_result = GLOBUS_SUCCESS;
     globus_result_t                     result;
     globus_bool_t                       finish = GLOBUS_TRUE;

--- a/gridftp/gridftp_driver/source/test/globus_gridftp_driver_test.c
+++ b/gridftp/gridftp_driver/source/test/globus_gridftp_driver_test.c
@@ -78,8 +78,8 @@ main(
     globus_bool_t                           append = GLOBUS_FALSE;
     globus_bool_t                           eret_esto = GLOBUS_FALSE;
     int                                     rc;
-    const char *                            filename;
-    char				    eret_esto_alg_str[ALG_NAME_LEN];
+    const char *                            filename = NULL;
+    char                                    eret_esto_alg_str[ALG_NAME_LEN];
     FILE *                                  fp;
     globus_ftp_client_handle_t              ftp_handle;
 
@@ -127,8 +127,8 @@ main(
         else if(strcmp(argv[ctr], "-u") == 0)
         {
             user_handle = GLOBUS_TRUE;
-	    res = globus_ftp_client_handle_init(&ftp_handle, GLOBUS_NULL);    
-	    test_res(res);
+            res = globus_ftp_client_handle_init(&ftp_handle, GLOBUS_NULL);
+            test_res(res);
         }
         else if(strcmp(argv[ctr], "-p") == 0)
         {
@@ -138,9 +138,9 @@ main(
         {
             if (ctr + 1 < argc)
             {
-	    	strcpy(eret_esto_alg_str, argv[ctr + 1]);
+                strcpy(eret_esto_alg_str, argv[ctr + 1]);
                 ctr++;
-		eret_esto = GLOBUS_TRUE;
+                eret_esto = GLOBUS_TRUE;
             }
         }
         else if(strcmp(argv[ctr], "-s") == 0)
@@ -200,16 +200,16 @@ main(
     }
     if (eret_esto)
     {
-	if (read)
-	{
+        if (read)
+        {
             res = globus_xio_attr_cntl(attr, gridftp_driver, 
                 GLOBUS_XIO_GRIDFTP_SET_ERET, eret_esto_alg_str);
-	}
-	else
-	{
+        }
+        else
+        {
             res = globus_xio_attr_cntl(attr, gridftp_driver, 
                 GLOBUS_XIO_GRIDFTP_SET_ESTO, eret_esto_alg_str);
-	}
+        }
         test_res(res);
     }
     if (subject)

--- a/gridftp/server-lib/src/configure.ac
+++ b/gridftp/server-lib/src/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gridftp_server_control],[9.2],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gridftp_server_control],[9.3],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gridftp/server-lib/src/globus_gridftp_server_control.c
+++ b/gridftp/server-lib/src/globus_gridftp_server_control.c
@@ -1974,7 +1974,7 @@ globus_l_gsc_flush_reads(
     globus_i_gsc_server_handle_t *      server_handle,
     const char *                        reply_msg)
 {
-    globus_result_t                     res;
+    globus_result_t                     res = GLOBUS_SUCCESS;
     globus_result_t                     tmp_res;
     globus_i_gsc_op_t *                 op;
     GlobusGridFTPServerName(globus_l_gsc_flush_reads);
@@ -4685,7 +4685,7 @@ globus_i_gsc_authenticate(
                     op->server_handle->subject,
                     buffer.length + 1,
                     "%s",
-                    buffer.value);
+                    (char *)buffer.value);
             }
             gss_release_buffer(&minor_stat, &buffer);
         }

--- a/gridftp/server-lib/src/globus_gridftp_server_control_accessors.c
+++ b/gridftp/server-lib/src/globus_gridftp_server_control_accessors.c
@@ -47,10 +47,7 @@ globus_gridftp_server_control_authenticated(
     globus_gridftp_server_control_t         server)
 {
     globus_bool_t                           rc = GLOBUS_TRUE;
-    globus_i_gsc_server_handle_t *          i_server;
     GlobusGridFTPServerName(globus_gridftp_server_control_authenticated);
-
-    i_server = (globus_i_gsc_server_handle_t *) server;
 
     if(server == NULL)
     {

--- a/gridftp/server-lib/src/globus_gridftp_server_control_commands.c
+++ b/gridftp/server-lib/src/globus_gridftp_server_control_commands.c
@@ -1089,12 +1089,9 @@ globus_l_gsc_cmd_quit(
     int                                     argc,
     void *                                  user_arg)
 {
-    globus_i_gsc_server_handle_t *          server_handle;
     GlobusGridFTPServerName(globus_l_gsc_cmd_quit);
 
     GlobusGridFTPServerDebugInternalEnter();
-
-    server_handle = op->server_handle;
 
     globus_i_gsc_log(op->server_handle, full_command,
         GLOBUS_GRIDFTP_SERVER_CONTROL_LOG_SECURITY);
@@ -1395,6 +1392,7 @@ globus_l_gsc_cmd_opts(
     
         tmp_ptr = cmd_a[2];
 
+        msg = _FSMSL("500 OPTS failed.\r\n");
         done = GLOBUS_FALSE;
         while(!done && *tmp_ptr != '\0')
         {

--- a/gridftp/server-lib/src/globus_xio_gssapi_ftp.c
+++ b/gridftp/server-lib/src/globus_xio_gssapi_ftp.c
@@ -511,7 +511,7 @@ globus_l_xio_gssapi_ftp_radix_decode(
 {
     int                                 i;
     int                                 j;
-    int                                 D;
+    int                                 D = 0;
     char *                              p;
     GlobusXIOName(globus_l_xio_gssapi_ftp_radix_decode);
 
@@ -601,7 +601,7 @@ globus_l_xio_gssapi_ftp_radix_encode(
 {
     int                                 i;
     int                                 j;
-    unsigned char                       c;
+    unsigned char                       c = 0;
     GlobusXIOName(globus_l_xio_gssapi_ftp_radix_encode);
 
     GlobusXIOGssapiftpDebugEnter();
@@ -1298,9 +1298,9 @@ globus_l_xio_gssapi_ftp_server_read_cb(
 {
     globus_l_xio_gssapi_ftp_handle_t *  handle;
     char *                              out_buf;
-    char *                              msg;
+    char *                              msg = NULL;
     globus_result_t                     res;
-    globus_bool_t                       complete;
+    globus_bool_t                       complete = GLOBUS_FALSE;
     globus_bool_t                       reply = GLOBUS_TRUE;
     char **                             cmd_a = NULL;
     globus_byte_t *                     in_buffer;
@@ -1485,7 +1485,7 @@ globus_l_xio_gssapi_ftp_server_read_cb(
                 globus_assert(0 && "Handle should be in reading state");
                 break;
         }
-        if(reply)
+        if(reply && msg)
         {
             /* send the entire reply */
             handle->auth_write_iov.iov_base = msg;

--- a/gridftp/server/multi/source/configure.ac
+++ b/gridftp/server/multi/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_xio_gridftp_multicast],[2.1],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_xio_gridftp_multicast],[2.2],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gridftp/server/multi/source/globus_xio_gridftp_multicast_driver.c
+++ b/gridftp/server/multi/source/globus_xio_gridftp_multicast_driver.c
@@ -243,7 +243,7 @@ xio_l_gmc_handle_destroy(
 
     if(handle->result != GLOBUS_SUCCESS)
     {
-        err_obj = globus_error_get(ftp_handle->result);
+        err_obj = globus_error_get(handle->result);
         globus_object_free(err_obj);
     }
     if(handle->local_url != NULL)
@@ -263,7 +263,6 @@ xio_l_gmc_make_ftp_error_list(
 {
     char *                              start_str;
     char *                              end_str;
-    int                                 len;
     char *                              error_url;
     globus_list_t *                     url_error_list = NULL;
     char *                              err_str;
@@ -297,15 +296,18 @@ xio_l_gmc_make_ftp_error_list(
         then we fail everything */
     tmp_str += sizeof(GMC_ERROR_TOKEN);
     start_str = tmp_str;
-    while(start_str != '\0')
+    while(*start_str != '\0')
     {
         end_str = strstr(start_str, "\n");
         if(end_str == NULL)
         {
             end_str = start_str + strlen(start_str);
         }
-        len = end_str - start_str;
-        *end_str = '\0';
+        else
+        {
+            *end_str = '\0';
+            end_str += 1;
+        }
 
         rc = globus_url_parse(start_str, &url_info);
         if(rc != GLOBUS_URL_SUCCESS)
@@ -322,6 +324,8 @@ xio_l_gmc_make_ftp_error_list(
 
         error_url = strdup(start_str);
         globus_list_insert(&url_error_list, error_url);
+
+        start_str = end_str;
     }
 
     return url_error_list;
@@ -1226,7 +1230,7 @@ xio_l_gridftp_multicast_write(
     int                                 iovec_count,
     globus_xio_operation_t              op)
 {
-    globus_size_t                       wait_for;
+    globus_size_t                       wait_for = 0;
     int                                 i;
     int                                 j;
     xio_l_gridftp_multicast_handle_t *  handle;

--- a/gridftp/server/src/configure.ac
+++ b/gridftp/server/src/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gridftp_server],[13.23],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gridftp_server],[13.24],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gridftp/server/src/gfs_dynbe_client.c
+++ b/gridftp/server/src/gfs_dynbe_client.c
@@ -172,6 +172,7 @@ main(
     rc = globus_module_activate(GLOBUS_XIO_MODULE);
     if(rc != 0)
     {
+        result = GLOBUS_FAILURE;
         goto error_activate;
     }
 
@@ -210,7 +211,7 @@ main(
     tmp32 = htonl(1);
     memcpy(&buffer[GF_DYN_ENTRY_COUNT_NDX], &tmp32, sizeof(uint32_t));
 
-    strncpy((char *) &buffer[GF_DYN_CS_NDX], be_cs, GF_DYN_CS_LEN);
+    strncpy((char *) &buffer[GF_DYN_CS_NDX], be_cs, GF_DYN_CS_LEN - 1);
 
     result = globus_xio_open(g_xio_handle, reg_cs, NULL);
     if(result != GLOBUS_SUCCESS)

--- a/gridftp/server/src/gfs_gfork_master.c
+++ b/gridftp/server/src/gfs_gfork_master.c
@@ -1568,7 +1568,7 @@ gfs_l_gfork_backend_xio_open_cb(
     memcpy(&buffer[GF_DYN_AT_ONCE_NDX], &converted_32, sizeof(uint32_t));
     converted_32 = htonl(g_total_cons);
     memcpy(&buffer[GF_DYN_TOTAL_NDX], &converted_32, sizeof(uint32_t));
-    strncpy((char *)&buffer[GF_DYN_CS_NDX], g_be_cs, GF_DYN_CS_LEN);
+    strncpy((char *)&buffer[GF_DYN_CS_NDX], g_be_cs, GF_DYN_CS_LEN - 1);
 
     result = globus_xio_register_write(
         handle,
@@ -2041,7 +2041,7 @@ gfs_l_gfork_opts_mem_size(
     int *                               out_parms_used)
 {
     globus_result_t                     result;
-    globus_off_t                        val;
+    globus_off_t                        val = 0;
 
     result = gfs_l_gfork_opts_kmgint(opt[0], &val);
     if(result != GLOBUS_SUCCESS)

--- a/gridftp/server/src/globus_gridftp_server.c
+++ b/gridftp/server/src/globus_gridftp_server.c
@@ -535,17 +535,16 @@ globus_l_gfs_spawn_child(
         /* inc the connection count 2 here since we will dec it on this close
         and on the death of the child process */
         globus_gfs_config_inc_int("open_connections_count", 2);
-        globus_mutex_unlock(&globus_l_gfs_mutex);
         result = globus_xio_register_close(
             handle,
             NULL,
             globus_l_gfs_close_cb,
-            NULL);    
+            NULL);
         if(result != GLOBUS_SUCCESS)
         {
-            globus_l_gfs_close_cb(handle, result, NULL);
-        }        
-    }    
+            globus_i_gfs_connection_closed();
+        }
+    }
 
     GlobusGFSDebugExit();
     return GLOBUS_SUCCESS;
@@ -613,7 +612,8 @@ globus_l_gfs_ipc_closed(
     }
 
     handle = (globus_xio_handle_t) user_arg;
-    globus_mutex_unlock(&globus_l_gfs_mutex);
+
+    globus_mutex_lock(&globus_l_gfs_mutex);
     {
         result = globus_xio_register_close(
             handle,

--- a/gridftp/server/src/globus_i_gfs_config.c
+++ b/gridftp/server/src/globus_i_gfs_config.c
@@ -1880,8 +1880,6 @@ globus_l_gfs_config_display_docbook_usage()
 
     for(i = 0; i < option_count; i++)
     {        
-        char *                          shortflag;
-        char *                          longflag;
         char *                          value;
         char *                          defval;
         
@@ -1909,27 +1907,19 @@ globus_l_gfs_config_display_docbook_usage()
         switch(o->type)
         {
           case GLOBUS_L_GFS_CONFIG_BOOL:
-            shortflag = "-";
-            longflag = "-";
             value = NULL;
             defval = o->int_value ? "TRUE" : "FALSE";
             break;
           case GLOBUS_L_GFS_CONFIG_INT:
-            shortflag = "-";
-            longflag = "-";
             value = "number"; 
             defval = o->int_value > 0 ? 
                 globus_common_create_string("%d", o->int_value) : NULL;
             break;
           case GLOBUS_L_GFS_CONFIG_STRING:
-            shortflag = "-";
-            longflag = "-";
             value = "string";
             defval = o->value ? o->value : NULL;
             break;
           default:
-            shortflag = "";
-            longflag = "";
             value = ""; 
             defval = o->value ? o->value : NULL;
             break;
@@ -2000,8 +1990,6 @@ globus_l_gfs_config_display_asciidoc_usage()
 
     for(i = 0; i < option_count; i++)
     {        
-        char *                          shortflag;
-        char *                          longflag;
         char *                          value;
         char *                          defval;
         
@@ -2034,27 +2022,19 @@ globus_l_gfs_config_display_asciidoc_usage()
         switch(o->type)
         {
           case GLOBUS_L_GFS_CONFIG_BOOL:
-            shortflag = "-";
-            longflag = "-";
             value = NULL;
             defval = o->int_value ? "TRUE" : "FALSE";
             break;
           case GLOBUS_L_GFS_CONFIG_INT:
-            shortflag = "-";
-            longflag = "-";
             value = "number"; 
             defval = o->int_value > 0 ? 
                 globus_common_create_string("%d", o->int_value) : NULL;
             break;
           case GLOBUS_L_GFS_CONFIG_STRING:
-            shortflag = "-";
-            longflag = "-";
             value = "string";
             defval = o->value ? o->value : NULL;
             break;
           default:
-            shortflag = "";
-            longflag = "";
             value = ""; 
             defval = o->value ? o->value : NULL;
             break;

--- a/gridftp/server/src/globus_i_gfs_embed.c
+++ b/gridftp/server/src/globus_i_gfs_embed.c
@@ -264,31 +264,25 @@ globus_l_gfs_ipc_closed(
     void *                              user_arg,
     globus_result_t                     result)
 {
-    globus_xio_handle_t                 xio_handle;
     globus_gfs_embed_handle_t           handle;
+    GlobusGFSName(globus_l_gfs_ipc_closed);
+    GlobusGFSDebugEnter();
 
     if(result != GLOBUS_SUCCESS)
     {
         /* XXX TODO log and error */
     }
 
-    xio_handle = (globus_xio_handle_t) user_arg;
-    globus_mutex_unlock(&handle->mutex);
+    handle = (globus_gfs_embed_handle_t) user_arg;
+
+    globus_mutex_lock(&handle->mutex);
     {
-        result = globus_xio_register_close(
-            xio_handle,
-            NULL,
-            globus_l_gfs_close_cb,
-            handle);
+        globus_i_gfs_connection_closed(handle);
     }
     globus_mutex_unlock(&handle->mutex);
 
-    if(result != GLOBUS_SUCCESS)
-    {
-        globus_l_gfs_close_cb(xio_handle, result, handle);
-    }
+    GlobusGFSDebugExit();
 }
-
 
 static
 void
@@ -380,7 +374,7 @@ globus_l_gfs_new_server_cb(
                 &globus_gfs_ipc_default_iface,
                 system_handle,
                 globus_l_gfs_ipc_closed,
-                xio_handle);
+                handle);
         }
         else
         {        

--- a/gridftp/server/src/globus_i_gfs_ipc.c
+++ b/gridftp/server/src/globus_i_gfs_ipc.c
@@ -4137,17 +4137,17 @@ globus_l_gfs_ipc_reply_read_body_cb(
     globus_byte_t *                     new_buf;
     globus_gfs_ipc_request_t *          request = user_arg;
     globus_i_gfs_ipc_handle_t *         ipc;
-    globus_gfs_command_info_t *         cmd_info;
-    globus_gfs_transfer_info_t *        trans_info;
-    globus_gfs_data_info_t *            data_info;
-    globus_gfs_stat_info_t *            stat_info;
+    globus_gfs_command_info_t *         cmd_info = NULL;
+    globus_gfs_transfer_info_t *        trans_info = NULL;
+    globus_gfs_data_info_t *            data_info = NULL;
+    globus_gfs_stat_info_t *            stat_info = NULL;
     globus_gfs_event_info_t *           event_info;
     globus_gfs_operation_type_t         type;
-    globus_byte_t *                     user_buffer;
-    globus_size_t                       user_buffer_length;
-    int                                 user_buffer_type;
+    globus_byte_t *                     user_buffer = NULL;
+    globus_size_t                       user_buffer_length = 0;
+    int                                 user_buffer_type = 0;
     int                                 rc;
-    void *                              data_arg;
+    void *                              data_arg = NULL;
     globus_bool_t                       process = GLOBUS_FALSE;
     int                                 error_state;
     int                                 no_reply_state;
@@ -4918,6 +4918,7 @@ globus_l_gfs_ipc_reply_cb(
                 goto error_already;
                 break;
             case GLOBUS_GFS_IPC_STATE_REPLY_WAIT:
+                error_state = GLOBUS_GFS_IPC_STATE_REPLY_WAIT;
                 break;
             default:
                 globus_assert(0 && "memory corruption?");

--- a/gridftp/server/src/globus_i_gfs_log.c
+++ b/gridftp/server/src/globus_i_gfs_log.c
@@ -85,7 +85,6 @@ globus_i_gfs_log_open()
     int                                 len;
     int                                 ctr;
     char *                              tag;
-    globus_result_t                     result;
     globus_reltime_t                    flush_interval;
     globus_size_t                       buffer;
     int                                 rc;
@@ -369,7 +368,6 @@ globus_i_gfs_log_open()
 void
 globus_i_gfs_log_close(void)
 {
-    globus_list_t *                     list;
     GlobusGFSName(globus_i_gfs_log_close);
     GlobusGFSDebugEnter();
 

--- a/gridftp/server/src/modules/remote/globus_gridftp_server_remote.c
+++ b/gridftp/server/src/modules/remote/globus_gridftp_server_remote.c
@@ -402,7 +402,7 @@ globus_l_gfs_remote_select_nodes(
     repo_name = bounce->repo;
     callback = bounce->callback;
     user_arg = bounce->user_arg;
-    nodes_requested = bounce->num_nodes;
+    nodes_requested = num_nodes;
 
     /* select a new set of nodes */
     result = globus_gfs_brain_select_nodes(
@@ -920,7 +920,6 @@ globus_l_gfs_ipc_event_cb(
     globus_l_gfs_remote_handle_t *      my_handle;
     int                                 i;
     globus_l_gfs_remote_ipc_bounce_t *  bounce_info;
-    globus_list_t *                     list;
     globus_bool_t                       finish = GLOBUS_FALSE;
     globus_l_gfs_remote_node_info_t *   current_node = NULL;
     globus_l_gfs_remote_node_info_t *   master_node = NULL;
@@ -981,8 +980,7 @@ globus_l_gfs_ipc_event_cb(
 
                 for(i = 0; i < bounce_info->node_handle->count; i++)
                 {
-                    node_info = (globus_l_gfs_remote_node_info_t *) 
-                        globus_list_first(list);
+                    node_info = bounce_info->node_handle->nodes[i];
                     info = (globus_gfs_transfer_info_t *) node_info->info;
                 
                     if(node_info->ipc_handle == ipc_handle)

--- a/gridftp/server/src/test/error_response_test.c
+++ b/gridftp/server/src/test/error_response_test.c
@@ -219,7 +219,6 @@ static
 bool
 test_error_multiline(void)
 {
-    globus_result_t                     result = GLOBUS_SUCCESS;
     globus_object_t                    *err = NULL;
     char                               *msg = NULL;
     char                               *ftp_str = NULL;

--- a/gsi/authz/source/configure.ac
+++ b/gsi/authz/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_authz],[4.5],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_authz],[4.6],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gsi/authz/source/test/authz_cred_test.c
+++ b/gsi/authz/source/test/authz_cred_test.c
@@ -55,7 +55,6 @@ int
 main(int argc, char **argv)
 {
     gss_cred_id_t                       credential;
-    struct context_arg *                arg = NULL;
     gss_buffer_desc                     init_token = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                     accept_token = GSS_C_EMPTY_BUFFER;
     OM_uint32                           maj_stat, min_stat;
@@ -63,9 +62,6 @@ main(int argc, char **argv)
     gss_ctx_id_t                        accept_ctx = GSS_C_NO_CONTEXT;
     globus_result_t                     result;
     globus_gsi_authz_handle_t           authz_handle;
-    char                                buf[128];
-    char *                              request_action;
-    char *                              request_object;
     char *                              identity;
     int                                 ok = -1;
     int                                 fail_count = 0;

--- a/gsi/gssapi_error/source/configure.ac
+++ b/gsi/gssapi_error/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gssapi_error],[6.2],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gssapi_error],[6.3],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gsi/gssapi_error/source/library/globus_error_gssapi.c
+++ b/gsi/gssapi_error/source/library/globus_error_gssapi.c
@@ -179,8 +179,6 @@ globus_error_gssapi_get_major_status(
  *        The error object for which to set the major status
  * @param major_status
  *        The major status
- * @return
- *        void
  */
 void
 globus_error_gssapi_set_major_status(

--- a/gsi/proxy/proxy_core/source/configure.ac
+++ b/gsi/proxy/proxy_core/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gsi_proxy_core],[9.7],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gsi_proxy_core],[9.8],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gsi/proxy/proxy_core/source/test/proxy-handle-compat-test.c
+++ b/gsi/proxy/proxy_core/source/test/proxy-handle-compat-test.c
@@ -29,44 +29,6 @@ struct test_case
 static int test_policy_nid;
 
 #define TEST_CASE_INITIALIZER(c) { #c, c }
-#if OPENSSL_VERSION_NUMBER < 0x10000000L
-#define GENERAL_NAME_set0_value(gn, t, dns) \
-    do \
-    { \
-        GENERAL_NAME *g = (gn); \
-        g->type = (t); \
-        g->d.dNSName = (dns);\
-    } \
-    while (0)
-#endif
-
-#define DEFINE_ASN1_CMP_OF(type, i2d) \
-    static int \
-    type##_cmp(type *A, type *B) \
-    { \
-        int res = 1; \
-        int alen = i2d(A, NULL); \
-        int blen = i2d(B, NULL); \
-        if (alen != blen) \
-        { \
-            res = 0; \
-        } \
-        else \
-        { \
-            unsigned char ader[alen]; \
-            unsigned char bder[blen]; \
-            unsigned char *aderptr = ader; \
-            unsigned char *bderptr = bder; \
-            i2d(A, &aderptr); \
-            i2d(B, &bderptr); \
-            res = !memcmp(ader, bder, alen); \
-        } \
-        return res; \
-    }
-
-DEFINE_ASN1_CMP_OF(X509_REQ, i2d_X509_REQ)
-DEFINE_ASN1_CMP_OF(X509_EXTENSION, i2d_X509_EXTENSION)
-
 
 static
 bool
@@ -74,7 +36,6 @@ proxy_handle_set_proxy_cert_info_compat_null_test(void)
 {
     bool                                ok = true;
     globus_result_t                     result = GLOBUS_SUCCESS;
-    globus_gsi_proxy_handle_t           handle = NULL;
 
     result = globus_gsi_proxy_handle_set_proxy_cert_info(NULL, NULL);
     if (result == GLOBUS_SUCCESS)

--- a/gsi/proxy/proxy_core/source/test/proxy-handle-test.c
+++ b/gsi/proxy/proxy_core/source/test/proxy-handle-test.c
@@ -85,8 +85,6 @@ static
 bool
 proxy_handle_destroy_null_test(void)
 {
-    globus_result_t                     result = GLOBUS_SUCCESS;
-
     globus_gsi_proxy_handle_destroy(NULL);
 
     return true;
@@ -1061,9 +1059,7 @@ bool
 proxy_handle_set_pathlen_null_test(void)
 {
     globus_result_t                     result = GLOBUS_SUCCESS;
-    globus_gsi_proxy_handle_t           handle = NULL;
     bool                                ok = true;
-    STACK_OF(X509_EXTENSION)           *extensions = NULL;
 
     result = globus_gsi_proxy_handle_set_pathlen(NULL, 0);
     if (result == GLOBUS_SUCCESS)
@@ -1240,7 +1236,6 @@ proxy_handle_set_proxy_cert_info_null_test(void)
 {
     bool                                ok = true;
     globus_result_t                     result = GLOBUS_SUCCESS;
-    globus_gsi_proxy_handle_t           handle = NULL;
 
     result = globus_gsi_proxy_handle_set_proxy_cert_info(NULL, NULL);
     if (result == GLOBUS_SUCCESS)
@@ -1489,7 +1484,6 @@ proxy_handle_set_is_limited_null_test(void)
     }
 
     globus_gsi_proxy_handle_destroy(handle);
-no_handle:
     return ok;
 }
 

--- a/gsi/sysconfig/source/configure.ac
+++ b/gsi/sysconfig/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gsi_sysconfig], [9.4],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gsi_sysconfig], [9.5],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gsi/sysconfig/source/library/globus_gsi_system_config.c
+++ b/gsi/sysconfig/source/library/globus_gsi_system_config.c
@@ -1664,8 +1664,8 @@ globus_gsi_sysconfig_get_cert_dir_win32(
              "found in any of the following locations: \n"
              "1) env. var. X509_CERT_DIR\n"
              "2) $HOME/.globus/certificates\n"
-             "3) /etc/grid-security/certificates"
-             "\n4) $GLOBUS_LOCATION/share/certificates\n")));
+             "3) /etc/grid-security/certificates\n"
+             "4) $GLOBUS_LOCATION/share/certificates\n")));
 
         goto done;
     }
@@ -5037,8 +5037,8 @@ globus_gsi_sysconfig_get_cert_dir_unix(
              "found in any of the following locations: \n"
              "1) env. var. X509_CERT_DIR\n"
              "2) $HOME/.globus/certificates\n"
-             "3) /etc/grid-security/certificates"
-             "\n4) $GLOBUS_LOCATION/share/certificates\n")));
+             "3) /etc/grid-security/certificates\n"
+             "4) $GLOBUS_LOCATION/share/certificates\n")));
 
         goto done;
     }

--- a/gsi/sysconfig/source/test/system-config-test.c
+++ b/gsi/sysconfig/source/test/system-config-test.c
@@ -154,9 +154,6 @@ int main(int argc, char *argv[])
     else if (strcmp(argv[1], "get_signing_policy_filename") == 0
         && argc == 4)
     {
-        char                           *signing_policy_filename = NULL;
-        char                           *ca_name_string = argv[1];
-
         globus_assert_string(0, "Test not implemented");
     }
     else if (strcmp(argv[1], "get_ca_cert_files") == 0

--- a/myproxy/source/configure.ac
+++ b/myproxy/source/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT([myproxy],[6.2.11])
+AC_INIT([myproxy],[6.2.12])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign])
 LT_INIT([dlopen win32-dll])

--- a/myproxy/source/gsi_socket.c
+++ b/myproxy/source/gsi_socket.c
@@ -632,8 +632,6 @@ GSI_SOCKET_authentication_init(GSI_SOCKET *self, gss_name_t accepted_peer_names[
     OM_uint32			req_flags = 0, ret_flags = 0;
     int				return_value = GSI_SOCKET_ERROR;
     gss_buffer_desc		gss_buffer = { 0 };
-    gss_name_t			target_name = GSS_C_NO_NAME;
-    gss_OID			target_name_type = GSS_C_NO_OID;
     int				i, rc=0, sock;
     FILE			*fp = NULL;
     char                        *cert_dir = NULL;

--- a/myproxy/source/gssapi.c
+++ b/myproxy/source/gssapi.c
@@ -86,8 +86,6 @@
 
 /*****************************  Common Section  *****************************/
 
-static const char plugin_id[] = "$Id: gssapi.c,v 1.9 2007/09/27 15:40:54 basney Exp $";
-
 static const char * GSSAPI_BLANK_STRING = "";
 
 #ifndef HAVE_GSS_C_NT_HOSTBASED_SERVICE
@@ -287,7 +285,8 @@ sasl_gss_seterror_(const sasl_utils_t *utils, OM_uint32 maj, OM_uint32 min,
     OM_uint32 msg_ctx;
     int ret;
     char *out = NULL;
-    size_t len, curlen = 0;
+    size_t len;
+    unsigned int curlen = 0;
     const char prefix[] = "GSSAPI Error: ";
     
     if(!utils) return;

--- a/myproxy/source/myproxy.c
+++ b/myproxy/source/myproxy.c
@@ -847,11 +847,10 @@ myproxy_authenticate_init(myproxy_socket_attrs_t *attrs,
            }
        }
    } else {
-       char *fqhn, *buf;
+       char *fqhn;
        if (new_server_identity_check_behavior_needed()) {
            OM_uint32 major_status, minor_status;
            gss_buffer_desc hostip;
-           int rc;
            static gss_OID_desc gss_nt_host_ip_oid =
                 { 10, "\x2b\x06\x01\x04\x01\x9b\x50\x01\x01\x02" };
            gss_OID_desc * gss_nt_host_ip = &gss_nt_host_ip_oid;
@@ -2844,7 +2843,7 @@ convert_message(const char			*buffer,
 	if (foundone == 1)
 	{
 	    /* No. Is that OK? */
-	    if (flags * CONVERT_MESSAGE_ALLOW_MULTIPLE)
+	    if (flags && CONVERT_MESSAGE_ALLOW_MULTIPLE)
 	    {
 		/* Yes. Add carriage return to existing line and concatenate */
 		*line = realloc(*line, line_index+2);

--- a/myproxy/source/myproxy_alcf.c
+++ b/myproxy/source/myproxy_alcf.c
@@ -95,7 +95,6 @@ int get_storage_dir_owner(uid_t *owner);
 
 int main(int argc, char *argv[])
 {
-    SSL_CREDENTIALS *creds;
     myproxy_creds_t my_creds = {0};
     char proxyfile[64] = "";
     int rval=1;
@@ -110,7 +109,6 @@ int main(int argc, char *argv[])
 
     myproxy_log_use_stream (stderr);
 
-    creds = ssl_credentials_new();
     init_arguments (argc, argv, &my_creds);
 
     if (certfile == NULL) {

--- a/myproxy/source/myproxy_server.c
+++ b/myproxy/source/myproxy_server.c
@@ -1945,8 +1945,7 @@ myproxy_authorize_accept(myproxy_server_context_t *context,
            if (!verror_is_error()) {
                /* if we don't have a good error message already,
                   it means we had insufficient authentication */
-               if (!client_request->passphrase ||
-                   client_request->passphrase[0] == '\0') {
+               if (client_request->passphrase[0] == '\0') {
                    verror_put_string("no passphrase");
                }
                verror_put_string("authentication failed");
@@ -2256,7 +2255,6 @@ authenticate_client(myproxy_socket_attrs_t *attrs,
    if (authcnt == 0) {
        /* if we already have a password, try it now */
        if (status[AUTHORIZETYPE_PASSWD] == AUTHORIZEMETHOD_SUFFICIENT &&
-	   client_request->passphrase &&
 	   client_request->passphrase[0] != '\0') {
 	   if (verify_passphrase(creds, client_request,
 				 client_name, config) == 1) {

--- a/myproxy/source/myproxy_server_config.c
+++ b/myproxy/source/myproxy_server_config.c
@@ -1344,8 +1344,6 @@ myproxy_server_check_policy_ext(const char *policy, myproxy_server_peer_t *clien
 	     strlen(MYPROXY_SERVER_POLICY_TYPE_SUBJECT)) == 0) {
        policy += strlen(MYPROXY_SERVER_POLICY_TYPE_SUBJECT);
     }
-    if (client->name == NULL)
-       return 0;
 
     return regex_compare(policy, client->name);
 }

--- a/myproxy/source/ssl_utils.c
+++ b/myproxy/source/ssl_utils.c
@@ -741,7 +741,7 @@ ssl_private_key_load_from_file(SSL_CREDENTIALS	*creds,
     }
 
     if ((key = PEM_read_PrivateKey(key_file, NULL, (pass_phrase_prompt) ?
-	    PEM_NO_CALLBACK : PEM_CALLBACK(my_pass_phrase_callback))) == NULL)
+            NULL : my_pass_phrase_callback, NULL)) == NULL)
     {
 	unsigned long error, reason;
 	

--- a/myproxy/source/vomsclient.c
+++ b/myproxy/source/vomsclient.c
@@ -223,7 +223,7 @@ voms_get_role_command(const char *str)
     memset(buf, '\0', buf_len);
 
     buf[i++] = 'R';
-    strncpy(&buf[i], p_role, role_len);
+    memcpy(&buf[i], p_role, role_len);
 
     return buf;
 }
@@ -268,10 +268,10 @@ voms_get_mapping_command(const char *str)
     if (str[0] != '/') {
         buf[i++] = '/';
     }
-    strncpy(&buf[i], str, group_len);
+    memcpy(&buf[i], str, group_len);
     i += group_len;
     buf[i++] = ':';
-    strncpy(&buf[i], p_role, role_len);
+    memcpy(&buf[i], p_role, role_len);
 
     return buf;
 }
@@ -304,7 +304,7 @@ voms_get_group_command(const char *str)
     if (str[0] != '/') {
        buf[i++] = '/';
     }
-    strncpy(&buf[i], str, str_len);
+    memcpy(&buf[i], str, str_len);
     buf_len = strlen(buf);
     if (buf[buf_len-1] == '/') {
         buf[buf_len-1] = '\0';

--- a/packaging/debian/globus-authz/debian/changelog.in
+++ b/packaging/debian/globus-authz/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-authz (4.6-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 09 Mar 2022 14:13:47 +0100
+
 globus-authz (4.5-1+gct.@distro@) @distro@; urgency=medium
 
   * Use sha256 hash when generating test certificates

--- a/packaging/debian/globus-common/debian/changelog.in
+++ b/packaging/debian/globus-common/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-common (18.12-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler and doxygen warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 09 Mar 2022 15:53:34 +0100
+
 globus-common (18.11-1+gct.@distro@) @distro@; urgency=medium
 
   * Typo fixes

--- a/packaging/debian/globus-ftp-client/debian/changelog.in
+++ b/packaging/debian/globus-ftp-client/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-ftp-client (9.8-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler and doxygen warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 09 Mar 2022 18:23:22 +0100
+
 globus-ftp-client (9.7-1+gct.@distro@) @distro@; urgency=medium
 
   * Use sha256 hash when generating test certificates

--- a/packaging/debian/globus-ftp-control/debian/changelog.in
+++ b/packaging/debian/globus-ftp-control/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-ftp-control (9.9-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler and doxygen warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 09 Mar 2022 18:24:03 +0100
+
 globus-ftp-control (9.8-1+gct.@distro@) @distro@; urgency=medium
 
   * Use sha256 hash when generating test certificates

--- a/packaging/debian/globus-gass-copy/debian/changelog.in
+++ b/packaging/debian/globus-gass-copy/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gass-copy (10.12-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler and doxygen warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 09 Mar 2022 19:12:59 +0100
+
 globus-gass-copy (10.11-1+gct.@distro@) @distro@; urgency=medium
 
   * Use sha256 hash when generating test certificates

--- a/packaging/debian/globus-gass-server-ez/debian/changelog.in
+++ b/packaging/debian/globus-gass-server-ez/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gass-server-ez (6.2-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 09 Mar 2022 19:24:17 +0100
+
 globus-gass-server-ez (6.1-1+gct.@distro@) @distro@; urgency=medium
 
   * Doxygen fixes

--- a/packaging/debian/globus-gass-transfer/debian/changelog.in
+++ b/packaging/debian/globus-gass-transfer/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gass-transfer (9.4-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler and doxygen warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Wed, 09 Mar 2022 20:37:44 +0100
+
 globus-gass-transfer (9.3-1+gct.@distro@) @distro@; urgency=medium
 
   * Typo fixes

--- a/packaging/debian/globus-gatekeeper/debian/changelog.in
+++ b/packaging/debian/globus-gatekeeper/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gatekeeper (11.4-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Thu, 10 Mar 2022 05:52:57 +0100
+
 globus-gatekeeper (11.3-1+gct.@distro@) @distro@; urgency=medium
 
   * Add AC_CONFIG_MACRO_DIR and ACLOCAL_AMFLAGS

--- a/packaging/debian/globus-gram-client-tools/debian/changelog.in
+++ b/packaging/debian/globus-gram-client-tools/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gram-client-tools (12.2-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 11 Mar 2022 19:10:38 +0100
+
 globus-gram-client-tools (12.1-1+gct.@distro@) @distro@; urgency=medium
 
   * Install globus-job-get-output-helper man page

--- a/packaging/debian/globus-gram-client/debian/changelog.in
+++ b/packaging/debian/globus-gram-client/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gram-client (14.6-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some doxygen warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 11 Mar 2022 19:08:23 +0100
+
 globus-gram-client (14.5-1+gct.@distro@) @distro@; urgency=medium
 
   * Use sha256 hash when generating test certificates

--- a/packaging/debian/globus-gram-job-manager-fork/debian/changelog.in
+++ b/packaging/debian/globus-gram-job-manager-fork/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gram-job-manager-fork (3.3-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 11 Mar 2022 19:05:53 +0100
+
 globus-gram-job-manager-fork (3.2-1+gct.@distro@) @distro@; urgency=medium
 
   * Typo fixes

--- a/packaging/debian/globus-gram-job-manager-sge/debian/changelog.in
+++ b/packaging/debian/globus-gram-job-manager-sge/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gram-job-manager-sge (3.3-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 11 Mar 2022 19:06:35 +0100
+
 globus-gram-job-manager-sge (3.2-1+gct.@distro@) @distro@; urgency=medium
 
   * Typo fixes

--- a/packaging/debian/globus-gram-job-manager/debian/changelog.in
+++ b/packaging/debian/globus-gram-job-manager/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gram-job-manager (15.8-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 11 Mar 2022 19:02:44 +0100
+
 globus-gram-job-manager (15.7-1+gct.@distro@) @distro@; urgency=medium
 
   * Use sha256 hash when generating test certificates

--- a/packaging/debian/globus-gridftp-server-control/debian/changelog.in
+++ b/packaging/debian/globus-gridftp-server-control/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gridftp-server-control (9.3-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Thu, 10 Mar 2022 09:20:27 +0100
+
 globus-gridftp-server-control (9.2-1+gct.@distro@) @distro@; urgency=medium
 
   * Typo fixes

--- a/packaging/debian/globus-gridftp-server/debian/changelog.in
+++ b/packaging/debian/globus-gridftp-server/debian/changelog.in
@@ -1,3 +1,10 @@
+globus-gridftp-server (13.24-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+  * Fix unbalanced mutex lock/unlock
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Thu, 10 Mar 2022 14:39:04 +0100
+
 globus-gridftp-server (13.23-1+gct.@distro@) @distro@; urgency=medium
 
   * Use sha256 hash when generating test certificates

--- a/packaging/debian/globus-gsi-proxy-core/debian/changelog.in
+++ b/packaging/debian/globus-gsi-proxy-core/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gsi-proxy-core (9.8-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Thu, 10 Mar 2022 14:53:03 +0100
+
 globus-gsi-proxy-core (9.7-1+gct.@distro@) @distro@; urgency=medium
 
   * Use sha256 when signing request

--- a/packaging/debian/globus-gsi-sysconfig/debian/changelog.in
+++ b/packaging/debian/globus-gsi-sysconfig/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gsi-sysconfig (9.5-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Thu, 10 Mar 2022 15:12:20 +0100
+
 globus-gsi-sysconfig (9.4-1+gct.@distro@) @distro@; urgency=medium
 
   * Typo fixes

--- a/packaging/debian/globus-gssapi-error/debian/changelog.in
+++ b/packaging/debian/globus-gssapi-error/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gssapi-error (6.3-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some doxygen warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Thu, 10 Mar 2022 15:43:26 +0100
+
 globus-gssapi-error (6.2-1+gct.@distro@) @distro@; urgency=medium
 
   * Make makefiles exit sooner on errors

--- a/packaging/debian/globus-scheduler-event-generator/debian/changelog.in
+++ b/packaging/debian/globus-scheduler-event-generator/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-scheduler-event-generator (6.5-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Thu, 10 Mar 2022 16:12:28 +0100
+
 globus-scheduler-event-generator (6.4-1+gct.@distro@) @distro@; urgency=medium
 
   * Keep admin script in sync with init script

--- a/packaging/debian/globus-xio-gridftp-driver/debian/changelog.in
+++ b/packaging/debian/globus-xio-gridftp-driver/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-xio-gridftp-driver (3.6-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 11 Mar 2022 08:11:03 +0100
+
 globus-xio-gridftp-driver (3.5-1+gct.@distro@) @distro@; urgency=medium
 
   * Use sha256 hash when generating test certificates

--- a/packaging/debian/globus-xio-gridftp-multicast/debian/changelog.in
+++ b/packaging/debian/globus-xio-gridftp-multicast/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-xio-gridftp-multicast (2.2-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 11 Mar 2022 09:41:33 +0100
+
 globus-xio-gridftp-multicast (2.1-1+gct.@distro@) @distro@; urgency=medium
 
   * Add AC_CONFIG_MACRO_DIR and ACLOCAL_AMFLAGS

--- a/packaging/debian/globus-xio/debian/changelog.in
+++ b/packaging/debian/globus-xio/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-xio (6.6-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler and doxygen warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 11 Mar 2022 03:28:28 +0100
+
 globus-xio (6.5-1+gct.@distro@) @distro@; urgency=medium
 
   * Typo fixes

--- a/packaging/debian/myproxy/debian/changelog.in
+++ b/packaging/debian/myproxy/debian/changelog.in
@@ -1,3 +1,9 @@
+myproxy (6.2.12-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix some compiler warnings
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 11 Mar 2022 13:25:38 +0100
+
 myproxy (6.2.11-1+gct.@distro@) @distro@; urgency=medium
 
   * Use sha256 when signing request

--- a/packaging/fedora/globus-authz.spec
+++ b/packaging/fedora/globus-authz.spec
@@ -3,7 +3,7 @@
 Name:		globus-authz
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	4.5
+Version:	4.6
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus authz library
 
@@ -137,6 +137,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Wed Mar 09 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 4.6-1
+- Fix some compiler warnings
+
 * Sun Mar 06 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 4.5-1
 - Use sha256 hash when generating test certificates
 

--- a/packaging/fedora/globus-common.spec
+++ b/packaging/fedora/globus-common.spec
@@ -3,7 +3,7 @@
 Name:		globus-common
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	18.11
+Version:	18.12
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Common Library
 
@@ -239,6 +239,9 @@ make %{?_smp_mflags} check VERBOSE=1 NO_EXTERNAL_NET=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Wed Mar 09 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 18.12-1
+- Fix some compiler and doxygen warnings
+
 * Fri Aug 20 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 18.11-1
 - Typo fixes
 

--- a/packaging/fedora/globus-ftp-client.spec
+++ b/packaging/fedora/globus-ftp-client.spec
@@ -3,7 +3,7 @@
 Name:		globus-ftp-client
 %global soname 2
 %global _name %(echo %{name} | tr - _)
-Version:	9.7
+Version:	9.8
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GridFTP Client Library
 
@@ -169,6 +169,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Wed Mar 09 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.8-1
+- Fix some compiler and doxygen warnings
+
 * Sun Mar 06 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.7-1
 - Use sha256 hash when generating test certificates
 

--- a/packaging/fedora/globus-ftp-control.spec
+++ b/packaging/fedora/globus-ftp-control.spec
@@ -3,7 +3,7 @@
 Name:		globus-ftp-control
 %global soname 1
 %global _name %(echo %{name} | tr - _)
-Version:	9.8
+Version:	9.9
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GridFTP Control Library
 
@@ -144,6 +144,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Wed Mar 09 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.9-1
+- Fix some compiler and doxygen warnings
+
 * Sun Mar 06 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.8-1
 - Use sha256 hash when generating test certificates
 

--- a/packaging/fedora/globus-gass-copy.spec
+++ b/packaging/fedora/globus-gass-copy.spec
@@ -3,7 +3,7 @@
 Name:		globus-gass-copy
 %global soname 2
 %global _name %(echo %{name} | tr - _)
-Version:	10.11
+Version:	10.12
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gass Copy
 
@@ -183,6 +183,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Wed Mar 09 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.12-1
+- Fix some compiler and doxygen warnings
+
 * Sun Mar 06 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.11-1
 - Use sha256 hash when generating test certificates
 

--- a/packaging/fedora/globus-gass-server-ez.spec
+++ b/packaging/fedora/globus-gass-server-ez.spec
@@ -3,7 +3,7 @@
 Name:		globus-gass-server-ez
 %global soname 2
 %global _name %(echo %{name} | tr - _)
-Version:	6.1
+Version:	6.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gass Server_ez
 
@@ -125,6 +125,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.la
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Wed Mar 09 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2-1
+- Fix some compiler warnings
+
 * Wed Nov 21 2018 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.1-1
 - Doxygen fixes
 

--- a/packaging/fedora/globus-gass-transfer.spec
+++ b/packaging/fedora/globus-gass-transfer.spec
@@ -3,7 +3,7 @@
 Name:		globus-gass-transfer
 %global soname 2
 %global _name %(echo %{name} | tr - _)
-Version:	9.3
+Version:	9.4
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gass Transfer
 
@@ -131,6 +131,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.la
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Wed Mar 09 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.4-1
+- Fix some compiler and doxygen warnings
+
 * Fri Aug 20 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.3-1
 - Typo fixes
 

--- a/packaging/fedora/globus-gatekeeper.spec
+++ b/packaging/fedora/globus-gatekeeper.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gatekeeper
 %global _name %(echo %{name} | tr - _)
-Version:	11.3
+Version:	11.4
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gatekeeper
 
@@ -129,6 +129,9 @@ fi
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Thu Mar 10 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 11.4-1
+- Fix some compiler warnings
+
 * Thu Jul 18 2019 Mattias Ellert <mattias.ellert@physics.uu.se> - 11.3-1
 - Add AC_CONFIG_MACRO_DIR and ACLOCAL_AMFLAGS
 

--- a/packaging/fedora/globus-gram-client-tools.spec
+++ b/packaging/fedora/globus-gram-client-tools.spec
@@ -3,7 +3,7 @@
 Name:		globus-gram-client-tools
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	12.1
+Version:	12.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Job Management Tools (globusrun)
 
@@ -70,6 +70,9 @@ make install DESTDIR=$RPM_BUILD_ROOT
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Fri Mar 11 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 12.2-1
+- Fix some compiler warnings
+
 * Mon Mar 16 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 12.1-1
 - Install globus-job-get-output-helper man page
 

--- a/packaging/fedora/globus-gram-client.spec
+++ b/packaging/fedora/globus-gram-client.spec
@@ -3,7 +3,7 @@
 Name:		globus-gram-client
 %global soname 3
 %global _name %(echo %{name} | tr - _)
-Version:	14.5
+Version:	14.6
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GRAM Client Library
 
@@ -137,6 +137,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Fri Mar 11 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 14.6-1
+- Fix some doxygen warnings
+
 * Sun Mar 06 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 14.5-1
 - Use sha256 hash when generating test certificates
 

--- a/packaging/fedora/globus-gram-job-manager-fork.spec
+++ b/packaging/fedora/globus-gram-job-manager-fork.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gram-job-manager-fork
 %global _name %(echo %{name} | tr - _)
-Version:	3.2
+Version:	3.3
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Fork Job Manager Support
 
@@ -173,6 +173,9 @@ fi
 %config(noreplace) %{_sysconfdir}/globus/scheduler-event-generator/available/fork
 
 %changelog
+* Fri Mar 11 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 3.3-1
+- Fix some compiler warnings
+
 * Fri Aug 20 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 3.2-1
 - Typo fixes
 

--- a/packaging/fedora/globus-gram-job-manager-sge.spec
+++ b/packaging/fedora/globus-gram-job-manager-sge.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gram-job-manager-sge
 %global _name %(echo %{name} | tr - _)
-Version:	3.2
+Version:	3.3
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Grid Engine Job Manager Support
 
@@ -177,6 +177,9 @@ fi
 %config(noreplace) %{_sysconfdir}/globus/scheduler-event-generator/available/sge
 
 %changelog
+* Fri Mar 11 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 3.3-1
+- Fix some compiler warnings
+
 * Fri Aug 20 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 3.2-1
 - Typo fixes
 

--- a/packaging/fedora/globus-gram-job-manager.spec
+++ b/packaging/fedora/globus-gram-job-manager.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gram-job-manager
 %global _name %(echo %{name} | tr - _)
-Version:	15.7
+Version:	15.8
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GRAM Jobmanager
 
@@ -169,6 +169,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %{_libdir}/libglobus_seg_job_manager.so
 
 %changelog
+* Fri Mar 11 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 15.8-1
+- Fix some compiler warnings
+
 * Sun Mar 06 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 15.7-1
 - Use sha256 hash when generating test certificates
 

--- a/packaging/fedora/globus-gridftp-server-control.spec
+++ b/packaging/fedora/globus-gridftp-server-control.spec
@@ -3,7 +3,7 @@
 Name:		globus-gridftp-server-control
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	9.2
+Version:	9.3
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GridFTP Server Library
 
@@ -112,6 +112,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.la
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Thu Mar 10 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.3-1
+- Fix some compiler warnings
+
 * Fri Aug 20 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.2-1
 - Typo fixes
 

--- a/packaging/fedora/globus-gridftp-server.spec
+++ b/packaging/fedora/globus-gridftp-server.spec
@@ -3,7 +3,7 @@
 Name:		globus-gridftp-server
 %global soname 6
 %global _name %(echo %{name} | tr - _)
-Version:	13.23
+Version:	13.24
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GridFTP Server
 
@@ -223,6 +223,10 @@ fi
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Thu Mar 10 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 13.24-1
+- Fix some compiler warnings
+- Fix unbalanced mutex lock/unlock
+
 * Sun Mar 06 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 13.23-1
 - Use sha256 hash when generating test certificates
 

--- a/packaging/fedora/globus-gsi-proxy-core.spec
+++ b/packaging/fedora/globus-gsi-proxy-core.spec
@@ -3,7 +3,7 @@
 Name:		globus-gsi-proxy-core
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	9.7
+Version:	9.8
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Proxy Core Library
 
@@ -143,6 +143,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Thu Mar 10 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.8-1
+- Fix some compiler warnings
+
 * Sun Mar 06 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.7-1
 - Use sha256 when signing request
 

--- a/packaging/fedora/globus-gsi-sysconfig.spec
+++ b/packaging/fedora/globus-gsi-sysconfig.spec
@@ -3,7 +3,7 @@
 Name:		globus-gsi-sysconfig
 %global soname 1
 %global _name %(echo %{name} | tr - _)
-Version:	9.4
+Version:	9.5
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI System Config Library
 
@@ -150,6 +150,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Thu Mar 10 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.5-1
+- Fix some compiler warnings
+
 * Fri Aug 20 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.4-1
 - Typo fixes
 

--- a/packaging/fedora/globus-gssapi-error.spec
+++ b/packaging/fedora/globus-gssapi-error.spec
@@ -3,7 +3,7 @@
 Name:		globus-gssapi-error
 %global soname 2
 %global _name %(echo %{name} | tr - _)
-Version:	6.2
+Version:	6.3
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GSSAPI Error Library
 
@@ -130,6 +130,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.la
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Thu Mar 10 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.3-1
+- Fix some doxygen warnings
+
 * Tue Mar 10 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2-1
 - Make makefiles exit sooner on errors
 

--- a/packaging/fedora/globus-scheduler-event-generator.spec
+++ b/packaging/fedora/globus-scheduler-event-generator.spec
@@ -3,7 +3,7 @@
 Name:		globus-scheduler-event-generator
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	6.4
+Version:	6.5
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Scheduler Event Generator
 
@@ -239,6 +239,9 @@ fi
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Thu Mar 10 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.5-1
+- Fix some compiler warnings
+
 * Thu Dec 17 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.4-1
 - Keep admin script in sync with init script
 

--- a/packaging/fedora/globus-xio-gridftp-driver.spec
+++ b/packaging/fedora/globus-xio-gridftp-driver.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-xio-gridftp-driver
 %global _name %(echo %{name} | tr - _)
-Version:	3.5
+Version:	3.6
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus XIO GridFTP Driver
 
@@ -152,6 +152,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Fri Mar 11 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 3.6-1
+- Fix some compiler warnings
+
 * Sun Mar 06 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 3.5-1
 - Use sha256 hash when generating test certificates
 

--- a/packaging/fedora/globus-xio-gridftp-multicast.spec
+++ b/packaging/fedora/globus-xio-gridftp-multicast.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-xio-gridftp-multicast
 %global _name %(echo %{name} | tr - _)
-Version:	2.1
+Version:	2.2
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus XIO GridFTP Multicast Driver
 
@@ -103,6 +103,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.la
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Fri Mar 11 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 2.2-1
+- Fix some compiler warnings
+
 * Thu Jul 18 2019 Mattias Ellert <mattias.ellert@physics.uu.se> - 2.1-1
 - Add AC_CONFIG_MACRO_DIR and ACLOCAL_AMFLAGS
 

--- a/packaging/fedora/globus-xio.spec
+++ b/packaging/fedora/globus-xio.spec
@@ -3,7 +3,7 @@
 Name:		globus-xio
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	6.5
+Version:	6.6
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus XIO Framework
 
@@ -140,6 +140,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Fri Mar 11 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.6-1
+- Fix some compiler and doxygen warnings
+
 * Fri Aug 20 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.5-1
 - Typo fixes
 

--- a/packaging/fedora/myproxy.spec
+++ b/packaging/fedora/myproxy.spec
@@ -2,7 +2,7 @@
 
 Name:           myproxy
 %global soname 6
-Version:        6.2.11
+Version:        6.2.12
 Release:        1%{?dist}
 Summary:        Manage X.509 Public Key Infrastructure (PKI) security credentials
 
@@ -387,6 +387,9 @@ fi
 %doc %{_pkgdocdir}/LICENSE*
 
 %changelog
+* Fri Mar 11 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.12-1
+- Fix some compiler warnings
+
 * Sun Mar 06 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.11-1
 - Use sha256 when signing request
 

--- a/xio/src/builtins/http/globus_xio_http_header_info.c
+++ b/xio/src/builtins/http/globus_xio_http_header_info.c
@@ -179,7 +179,7 @@ globus_i_xio_http_header_info_set_header(
     /* Special cases for entity-body handling headers */
     if (strcasecmp(header_name, "Content-Length") == 0)
     {
-        rc = globus_libc_scan_off_t(header_value, &length, NULL);
+        rc = globus_libc_scan_off_t((char *)header_value, &length, NULL);
         if (rc < 1)
         {
             result = GlobusXIOHttpErrorInvalidHeader(header_name, header_value);

--- a/xio/src/builtins/http/globus_xio_http_transform.c
+++ b/xio/src/builtins/http/globus_xio_http_transform.c
@@ -1392,7 +1392,7 @@ globus_i_xio_http_write(
     globus_xio_operation_t                  op)
 {
     globus_i_xio_http_handle_t *            http_handle = handle;
-    globus_result_t                         result;
+    globus_result_t                         result = GLOBUS_SUCCESS;
     globus_i_xio_http_header_info_t *       headers;
     GlobusXIOName(globus_i_xio_http_write);
 
@@ -1742,7 +1742,7 @@ globus_i_xio_http_close(
     void *                              attr,
     globus_xio_operation_t              op)
 {
-    globus_result_t                     result;
+    globus_result_t                     result = GLOBUS_SUCCESS;
     globus_i_xio_http_handle_t *        http_handle = handle;
     GlobusXIOName(globus_i_xio_http_close);
 

--- a/xio/src/builtins/tcp/globus_xio_tcp_driver.c
+++ b/xio/src/builtins/tcp/globus_xio_tcp_driver.c
@@ -1378,7 +1378,7 @@ globus_l_xio_tcp_create_listener(
     globus_addrinfo_t *                 save_addrinfo;
     globus_addrinfo_t *                 addrinfo;
     globus_addrinfo_t                   addrinfo_hints;
-    char                                portbuf[10];
+    char                                portbuf[12];
     char *                              port;
     globus_xio_system_socket_t          fd;
     globus_bool_t                       try_again = GLOBUS_FALSE;

--- a/xio/src/builtins/telnet/globus_xio_telnet.c
+++ b/xio/src/builtins/telnet/globus_xio_telnet.c
@@ -445,7 +445,7 @@ globus_l_xio_telnet_attr_copy(
     void *                              src_driver_attr)
 {
     globus_l_xio_telnet_attr_t *        src_attr;
-    globus_l_xio_telnet_attr_t *       dest_attr;
+    globus_l_xio_telnet_attr_t *        dest_attr = NULL;
     globus_result_t                     res;
     GlobusXIOName(globus_l_xio_telnet_attr_init);
 

--- a/xio/src/builtins/udp/globus_xio_udp_driver.c
+++ b/xio/src/builtins/udp/globus_xio_udp_driver.c
@@ -974,7 +974,7 @@ globus_l_xio_udp_create_listener(
     globus_addrinfo_t *                 save_addrinfo;
     globus_addrinfo_t *                 addrinfo;
     globus_addrinfo_t                   addrinfo_hints;
-    char                                portbuf[10];
+    char                                portbuf[12];
     char *                              port;
     globus_xio_system_socket_t          fd;
     globus_bool_t                       try_again = GLOBUS_FALSE;

--- a/xio/src/configure.ac
+++ b/xio/src/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_xio], [6.5], [https://github.com/gridcf/gct/issues])
+AC_INIT([globus_xio], [6.6], [https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST(MAJOR_VERSION, [${PACKAGE_VERSION%%.*}])
 AC_SUBST(MINOR_VERSION, [${PACKAGE_VERSION##*.}])

--- a/xio/src/globus_xio.h
+++ b/xio/src/globus_xio.h
@@ -514,7 +514,7 @@ globus_xio_handle_create(
  *         GLOBUS_XIO_OPERATION_READ
  *         GLOBUS_XIO_OPERATION_WRITE
  *
- *  @param arg
+ *  @param user_arg
  *         A user arg threaded through to the callback.
  */
 

--- a/xio/src/globus_xio_driver.c
+++ b/xio/src/globus_xio_driver.c
@@ -253,13 +253,10 @@ globus_i_xio_handle_dec(
     globus_bool_t *                     destroy_handle)
 {
     globus_result_t                     res;
-    globus_i_xio_context_t *            context;
     globus_i_xio_space_info_t *         space_info;
     GlobusXIOName(globus_i_xio_handle_dec);
 
     GlobusXIODebugInternalEnter();
-
-    context = handle->context;
 
     *destroy_handle = GLOBUS_FALSE;
 
@@ -519,12 +516,9 @@ globus_l_xio_driver_op_write_kickout(
     void *                              user_arg)
 {
     globus_xio_operation_type_t         deliver_type;
-    globus_xio_operation_type_t         op_type;
     int                                 ndx;
     int                                 wb_ndx;
     globus_i_xio_handle_t *             handle;
-    globus_i_xio_context_entry_t *      my_context;
-    globus_i_xio_context_t *            context;
     globus_i_xio_op_entry_t *           my_op;
     globus_i_xio_op_t *                 op;
     GlobusXIOName(globus_l_xio_driver_op_write_kickout);
@@ -536,9 +530,7 @@ globus_l_xio_driver_op_write_kickout(
     op->entry[my_op->prev_ndx].next_ndx = op->ndx;
     op->ndx = my_op->prev_ndx;
     ndx = op->ndx;
-    my_context = &op->_op_context->entry[ndx];
     handle = op->_op_handle;
-    context = op->_op_context;
 
     GlobusIXIOClearCancel(op);
 
@@ -548,7 +540,6 @@ globus_l_xio_driver_op_write_kickout(
      *  on the local stack may be changed, theus the magic.
      */
     deliver_type = my_op->type;
-    op_type = my_op->type;
     my_op->deliver_type = &deliver_type;
 
     if(ndx == 0)
@@ -592,12 +583,9 @@ globus_l_xio_driver_op_read_kickout(
     void *                              user_arg)
 {
     globus_xio_operation_type_t         deliver_type;
-    globus_xio_operation_type_t         op_type;
     int                                 ndx;
     int                                 wb_ndx;
     globus_i_xio_handle_t *             handle;
-    globus_i_xio_context_entry_t *      my_context;
-    globus_i_xio_context_t *            context;
     globus_i_xio_op_entry_t *           my_op;
     globus_i_xio_op_t *                 op;
     GlobusXIOName(globus_l_xio_driver_op_read_kickout);
@@ -609,9 +597,7 @@ globus_l_xio_driver_op_read_kickout(
     op->entry[my_op->prev_ndx].next_ndx = op->ndx;
     op->ndx = my_op->prev_ndx;
     ndx = op->ndx;
-    my_context = &op->_op_context->entry[ndx];
     handle = op->_op_handle;
-    context = op->_op_context;
 
     GlobusIXIOClearCancel(op);
     
@@ -621,7 +607,6 @@ globus_l_xio_driver_op_read_kickout(
      *  on the local stack may be changed, theus the magic.
      */
     deliver_type = my_op->type;
-    op_type = my_op->type;
     my_op->deliver_type = &deliver_type;
 
     if(ndx == 0)
@@ -869,8 +854,6 @@ globus_l_xio_driver_open_op_kickout(
     void *                              user_arg)
 {
     globus_i_xio_handle_t *             handle;
-    globus_i_xio_context_t *            context;
-    globus_i_xio_context_entry_t *      my_context;
     int                                 ndx = 0;
     int                                 wb_ndx;
     globus_i_xio_op_entry_t *           my_op;
@@ -885,9 +868,7 @@ globus_l_xio_driver_open_op_kickout(
     my_op = &op->entry[op->ndx - 1];
     op->ndx = my_op->prev_ndx;
     ndx = op->ndx;
-    my_context = &op->_op_context->entry[ndx];
     handle = op->_op_handle;
-    context = op->_op_context;
 
     deliver_type = my_op->type;
     my_op->deliver_type =&deliver_type;

--- a/xio/src/globus_xio_driver.h
+++ b/xio/src/globus_xio_driver.h
@@ -402,7 +402,7 @@ typedef globus_result_t
  */
 typedef globus_result_t
 (*globus_xio_driver_attr_cntl_t)(
-    void *                              attr,
+    void *                              driver_attr,
     int                                 cmd,
     va_list                             ap);
 
@@ -474,9 +474,6 @@ globus_xio_driver_pass_server_init(
  *
  *  When this function is called the driver should free up all resources
  *  associated with a server.
- *
- *  @param server
- *         The server that the driver should clean up.
  *
  *  @param driver_server
  *         The reference to the internal server that is being declared
@@ -808,7 +805,7 @@ globus_xio_driver_merge_handle(
  */
 typedef globus_result_t
 (*globus_xio_driver_close_t)(
-    void *                              driver_handle,
+    void *                              driver_specific_handle,
     void *                              driver_attr,
     globus_xio_operation_t              op);
 
@@ -865,7 +862,7 @@ globus_xio_driver_finished_close(
  *  a handle.  The driver author shall implement all code needed to for
  *  there driver to complete a read operations.
  *
- *  @param driver_handle
+ *  @param driver_specific_handle
  *          The driver handle from which data should be read.
  *
  *  @param iovec
@@ -1015,7 +1012,7 @@ globus_xio_driver_eof_received(
  *  a handle.  The driver author shall implement all code needed to for
  *  there driver to complete write operations.
  *
- *  @param driver_handle
+ *  @param driver_specific_handle
  *          The driver handle to which data should be written.
  *
  *  @param iovec

--- a/xio/src/globus_xio_pass.c
+++ b/xio/src/globus_xio_pass.c
@@ -397,7 +397,6 @@ globus_xio_driver_pass_close(
     void *                              in_ua)
 {
     globus_i_xio_op_t *                 op;
-    globus_i_xio_handle_t *             handle;
     globus_i_xio_context_t *            context;
     globus_i_xio_context_entry_t *      my_context;
     globus_bool_t                       pass;
@@ -412,7 +411,6 @@ globus_xio_driver_pass_close(
     GlobusXIODebugInternalEnter();
     op = (in_op);
     globus_assert(op->ndx < op->stack_size);
-    handle = op->_op_handle;
     context = op->_op_context;
     op->progress = GLOBUS_TRUE;
     op->block_timeout = GLOBUS_FALSE;

--- a/xio/src/globus_xio_wrapblock.c
+++ b/xio/src/globus_xio_wrapblock.c
@@ -20,7 +20,6 @@
 #include "globus_xio_load.h"
 #include "globus_common.h"
 #include "globus_xio_wrapblock.h"
-#include "version.h"
 
 typedef struct xio_l_wrapblock_handle_s
 {

--- a/xio/src/test/cancel_test.c
+++ b/xio/src/test/cancel_test.c
@@ -186,7 +186,6 @@ cancel_main(
     globus_xio_handle_t                     handle;
     globus_result_t                         res;
     globus_xio_attr_t                       attr;
-    int                                     opt_offset;
     int                                     secs;
     int                                     usecs;
 

--- a/xio/src/test/close_barrier2_test.c
+++ b/xio/src/test/close_barrier2_test.c
@@ -142,7 +142,6 @@ close_barrier2_main(
     globus_xio_stack_t                      stack;
     globus_xio_handle_t                     handle;
     globus_result_t                         res;
-    globus_abstime_t                        end_time;
     globus_xio_attr_t                       attr;
 
     globus_l_close_called = GLOBUS_FALSE;

--- a/xio/src/test/drivers/globus_xio_smtp.c
+++ b/xio/src/test/drivers/globus_xio_smtp.c
@@ -338,7 +338,7 @@ globus_l_xio_smtp_open(
 
     globus_l_xio_smtp_attr_copy((void **)&info, driver_attr);
 
-    globus_xio_driver_pass_open(
+    res = globus_xio_driver_pass_open(
         op, contact_info, globus_l_xio_smtp_open_cb, info);
 
     return res;
@@ -386,7 +386,8 @@ globus_l_xio_smtp_close(
     sprintf(info->message, "\r\n.\r\nQUIT\r\n");
     info->iovec.iov_base = info->message;
     info->iovec.iov_len = strlen(info->message);
-    globus_xio_driver_pass_write(op, &info->iovec, 1, info->iovec.iov_len,
+    res = globus_xio_driver_pass_write(
+        op, &info->iovec, 1, info->iovec.iov_len,
         globus_l_xio_smtp_write_close_cb, (void *)info);
 
     return res;
@@ -418,14 +419,11 @@ globus_l_xio_smtp_write(
 {
     globus_result_t                     res;
     globus_size_t                       wait_for;
-    l_smtp_info_t *                     info;
-
-    info = (l_smtp_info_t *) driver_specific_handle;
 
     wait_for = globus_xio_operation_get_wait_for(op);
 
-    globus_xio_driver_pass_write(op, 
-        (globus_xio_iovec_t *)iovec, iovec_count, wait_for,
+    res = globus_xio_driver_pass_write(
+        op, (globus_xio_iovec_t *)iovec, iovec_count, wait_for,
         globus_l_xio_smtp_write_cb, NULL);
 
     return res;

--- a/xio/src/test/framework_test.c
+++ b/xio/src/test/framework_test.c
@@ -52,10 +52,6 @@ close_cb(
     globus_result_t                             result,
     void *                                      user_arg)
 {
-    test_info_t *                               info;
-
-    info = (test_info_t *) user_arg;
-
     globus_mutex_lock(&globus_l_mutex);
     {
         globus_l_closed = GLOBUS_TRUE;

--- a/xio/src/test/http_get_test.c
+++ b/xio/src/test/http_get_test.c
@@ -528,7 +528,6 @@ globus_l_xio_test_read_buffer(
 {
     globus_size_t                       offset=0;
     globus_size_t                       left = message_size;
-    globus_size_t                       to_read;
     globus_size_t                       nbytes;
     globus_result_t                     result = GLOBUS_SUCCESS;
     globus_byte_t *                     buffer;
@@ -548,8 +547,6 @@ globus_l_xio_test_read_buffer(
     while ((left > 0) || (result == GLOBUS_SUCCESS))
     {
         nbytes = 0;
-        to_read = (left > buffer_size) ? buffer_size : 
-                (left > 0 ? left : buffer_size);
         result = globus_xio_read(
                 handle,
                 buffer,

--- a/xio/src/test/http_pingpong_test.c
+++ b/xio/src/test/http_pingpong_test.c
@@ -243,7 +243,7 @@ server_test(
     http_test_info_t *			info,
     int					timer)
 {
-    int                                 rc;
+    int                                 rc = 0;
     globus_result_t                     result;
     http_test_server_t                  test_server;
 

--- a/xio/src/test/http_post_test.c
+++ b/xio/src/test/http_post_test.c
@@ -579,7 +579,6 @@ globus_l_xio_test_read_buffer(
 {
     globus_size_t                       offset=0;
     globus_size_t                       left = message_size;
-    globus_size_t                       to_read;
     globus_size_t                       nbytes;
     globus_result_t                     result = GLOBUS_SUCCESS;
     globus_byte_t *                     buffer;
@@ -599,8 +598,6 @@ globus_l_xio_test_read_buffer(
     while ((left > 0) || (result == GLOBUS_SUCCESS))
     {
         nbytes = 0;
-        to_read = (left > buffer_size) ? buffer_size : 
-                (left > 0 ? left : buffer_size);
         result = globus_xio_read(
                 handle,
                 buffer,

--- a/xio/src/test/http_put_test.c
+++ b/xio/src/test/http_put_test.c
@@ -500,7 +500,6 @@ globus_l_xio_test_read_buffer(
 {
     globus_size_t                       offset=0;
     globus_size_t                       left = message_size;
-    globus_size_t                       to_read;
     globus_size_t                       nbytes;
     globus_result_t                     result = GLOBUS_SUCCESS;
     globus_byte_t *                     buffer;
@@ -520,8 +519,6 @@ globus_l_xio_test_read_buffer(
     while ((left > 0) || (result == GLOBUS_SUCCESS))
     {
         nbytes = 0;
-        to_read = (left > buffer_size) ? buffer_size : 
-                (left > 0 ? left : buffer_size);
         result = globus_xio_read(
                 handle,
                 buffer,


### PR DESCRIPTION
This PR addresses the following compiler and doxygen warnings:

### globus-authz ###
```
authz_cred_test.c:68:41: warning: unused variable 'request_object' [-Wunused-variable]
authz_cred_test.c:67:41: warning: unused variable 'request_action' [-Wunused-variable]
authz_cred_test.c:66:41: warning: unused variable 'buf' [-Wunused-variable]
authz_cred_test.c:58:41: warning: unused variable 'arg' [-Wunused-variable]
```
### globus-common ###
```
globus_options.c:117:13: warning: argument 1 null where non-null expected [-Wnonnull]
globus_args.c:94:5: warning: 'strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
globus_error_errno.c:265:41: warning: unused variable 'source_module' [-Wunused-variable]
globus_libc.c:369:9: warning: 'strncpy' specified bound 64 equals destination size [-Wstringop-truncation]
error_test.c:122:49: warning: unused variable 'j' [-Wunused-variable]
error_test.c:121:49: warning: unused variable 'type' [-Wunused-variable]
fifo_test.c:51:45: warning: unused variable 'errorsOccurred' [-Wunused-variable]
fifo_test.c:46:45: warning: unused variable 'rc' [-Wunused-variable]
fifo_test.c:106:26: warning: 'middleItem' may be used uninitialized [-Wmaybe-uninitialized]
globus_args_scan_test.c:245:9: warning: unused variable 'i' [-Wunused-variable]
module_test.c:145:11: warning: suggest parentheses around comparison in operand of '&' [-Wparentheses]
module_test.c:106:41: warning: unused variable 'successful_tests' [-Wunused-variable]
memory_test.c:115:17: warning: unused variable 'p' [-Wunused-variable]
timedwait_test.c:53:25: warning: unused variable 'successful_tests' [-Wunused-variable]
poll_test.c:191:41: warning: unused variable 'tests_passed' [-Wunused-variable]
poll_test.c:812:41: warning: unused variable 'tmp' [-Wunused-variable]
```
#### doxygen ####
```
library/globus_callback.h:595: warning: documented empty return type of globus_callback_signal_poll
library/globus_callback.h:549: warning: documented empty return type of globus_callback_space_poll
library/globus_thread.c:1552: warning: return value 'GLOBUS_TRUE' of globus_thread_equal has multiple documentation sections
```
### globus-ftp-client ###
```
globus_ftp_client_attr.c:199:54: warning: 'c' may be used uninitialized [-Wmaybe-uninitialized]
globus_ftp_client_test_pause_plugin.c:266:19: warning: unused variable 'myname' [-Wunused-variable]
globus_ftp_client_test_pause_plugin.c:266:19: warning: 'myname' defined but not used [-Wunused-variable]
globus_ftp_client_test_pause_plugin.c:183:1: warning: 'globus_l_ftp_client_test_pause_plugin_command' defined but not used [-Wunused-function]
globus_ftp_client_test_restart_plugin.c:109:8: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
globus_ftp_client_test_restart_plugin.c:879:52: warning: suggest parentheses around '&&' within '||' [-Wparentheses]
globus_ftp_client_test_restart_plugin.c:1060:1: warning: 'globus_l_ftp_client_test_restart_plugin_complete' defined but not used [-Wunused-function]
cksm-test.c:59:49: warning: unused variable 'buffer_length' [-Wunused-variable]
chmod-test.c:101:14: warning: 'mode' may be used uninitialized [-Wmaybe-uninitialized]
chgrp-test.c:101:14: warning: 'group' may be used uninitialized [-Wmaybe-uninitialized]
exist-test.c:59:49: warning: unused variable 'buffer_length' [-Wunused-variable]
lingering-get-test.c:70:5: warning: implicit declaration of function 'test_parse_args' [-Wimplicit-function-declaration]
lingering-get-test.c:58:49: warning: unused variable 'buffer_length' [-Wunused-variable]
modification-time-test.c:63:49: warning: unused variable 'tm' [-Wunused-variable]
modification-time-test.c:59:49: warning: unused variable 'buffer_length' [-Wunused-variable]
multiget-test.c:58:47: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
multiget-test.c:151:51: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
multiget-test.c:91:49: warning: unused variable 'result' [-Wunused-variable]
multiget-test.c:206:55: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
multiple-block-put-test.c:67:29: warning: format '%d' expects argument of type 'int', but argument 2 has type 'globus_size_t' {aka 'long unsigned int'} [-Wformat=]
size-test.c:59:49: warning: unused variable 'buffer_length' [-Wunused-variable]
```
#### doxygen ####
```
globus_ftp_client_perf_plugin.h:95: warning: argument 'time_stamp' of command @param is not found in the argument list of globus_ftp_client_perf_plugin_marker_cb_t(void *user_specific, globus_ftp_client_handle_t *handle, long time_stamp_int, char time_stamp_tength, int stripe_ndx, int num_stripes, globus_off_t nbytes)
globus_ftp_client_perf_plugin.h:95: warning: The following parameters of globus_ftp_client_perf_plugin_marker_cb_t(void *user_specific, globus_ftp_client_handle_t *handle, long time_stamp_int, char time_stamp_tength, int stripe_ndx, int num_stripes, globus_off_t nbytes) are not documented:
  parameter 'time_stamp_int'
  parameter 'time_stamp_tength'
globus_ftp_client_plugin.h:153: warning: The following parameter of globus_ftp_client_plugin_connect_t(globus_ftp_client_plugin_t *plugin, void *plugin_specific, globus_ftp_client_handle_t *handle, const char *url) is not documented:
  parameter 'url'
globus_ftp_client_plugin.h:1065: warning: The following parameter of globus_ftp_client_plugin_data_t(globus_ftp_client_plugin_t *plugin, void *plugin_specific, globus_ftp_client_handle_t *handle, globus_object_t *error, const globus_byte_t *buffer, globus_size_t length, globus_off_t offset, globus_bool_t eof) is not documented:
  parameter 'error'
globus_ftp_client_plugin.h:328: warning: argument 'link_url' of command @param is not found in the argument list of globus_ftp_client_plugin_symlink_t(globus_ftp_client_plugin_t *plugin, void *plugin_specific, globus_ftp_client_handle_t *handle, const char *url, const char *utime_time, const globus_ftp_client_operationattr_t *attr, globus_bool_t restart)
globus_ftp_client_plugin.h:328: warning: The following parameter of globus_ftp_client_plugin_symlink_t(globus_ftp_client_plugin_t *plugin, void *plugin_specific, globus_ftp_client_handle_t *handle, const char *url, const char *utime_time, const globus_ftp_client_operationattr_t *attr, globus_bool_t restart) is not documented:
  parameter 'utime_time'
```
#### other fixes ####
```
Spelling:
time_stamp_tenght -> time_stamp_tenth
time_stamp_tength -> time_stamp_tenth
```
### globus-ftp-control ###
```
globus_ftp_control_server.c:1405:15: warning: format '%s' expects argument of type 'char *', but argument 4 has type 'void *' [-Wformat=]
globus_ftp_control_server.c:1311:41: warning: unused variable 'src_name' [-Wunused-variable]
globus_ftp_control_client.c:4293:35: warning: 'c' may be used uninitialized [-Wmaybe-uninitialized]
globus_ftp_control_client.c:4391:14: warning: 'D' may be used uninitialized [-Wmaybe-uninitialized]
globus_ftp_control_client.c:2277:11: warning: 'read_queue_empty' may be used uninitialized [-Wmaybe-uninitialized]
globus_ftp_control_data.c:4513:49: warning: variable 'transfer_handle' set but not used [-Wunused-but-set-variable]
globus_ftp_control_data.c:5080:49: warning: variable 'transfer_handle' set but not used [-Wunused-but-set-variable]
globus_ftp_control_data.c:7657:50: warning: variable 'transfer_handle' set but not used [-Wunused-but-set-variable]
globus_ftp_control_data.c:7904:50: warning: variable 'destroy_it' set but not used [-Wunused-but-set-variable]
globus_ftp_control_data.c:7976:50: warning: variable 'transfer_handle' set but not used [-Wunused-but-set-variable]
/usr/include/globus/globus_libc.h:155:33: warning: 'eof_cb_ent' may be used uninitialized [-Wmaybe-uninitialized]
globus_ftp_control_data.c:4713:49: warning: 'result' may be used uninitialized [-Wmaybe-uninitialized]
abort_test.c:89:35: warning: pointer targets in passing argument 1 of 'pasv_to_host_port' differ in signedness [-Wpointer-sign]
test_common.c:231:46: warning: unused variable 'tmp' [-Wunused-variable]
connect_test.c:246:1: warning: label 'use_tls_fail' defined but not used [-Wunused-label]
connect_test.c:177:41: warning: unused variable 'auth_info' [-Wunused-variable]
connect_test.c:341:1: warning: label 'use_tls_fail' defined but not used [-Wunused-label]
connect_test.c:271:41: warning: unused variable 'auth_info' [-Wunused-variable]
connect_test.c:366:41: warning: unused variable 'auth_info' [-Wunused-variable]
connect_test.c:837:41: warning: unused variable 'tmp_ptr' [-Wunused-variable]
connect_test.c:1138:1: warning: label 'failed_other_attr_init' defined but not used [-Wunused-label]
outstanding_io_test.c:330:39: warning: pointer targets in passing argument 1 of 'pasv_to_host_port' differ in signedness [-Wpointer-sign]
eb_simple_data_test.c:404:39: warning: pointer targets in passing argument 1 of 'pasv_to_host_port' differ in signedness [-Wpointer-sign]
data_test.c:1150:42: warning: unused variable 'sys_cmd' [-Wunused-variable]
data_test.c:1265:47: warning: unused variable 'sys_cmd' [-Wunused-variable]
data_test.c:1420:47: warning: unused variable 'sys_cmd' [-Wunused-variable]
data_test.c:1563:48: warning: unused variable 'ctr' [-Wunused-variable]
data_test.c:1561:48: warning: unused variable 'done' [-Wunused-variable]
simple_data_test.c:317:39: warning: pointer targets in passing argument 1 of 'pasv_to_host_port' differ in signedness [-Wpointer-sign]
test_server.c:143:46: warning: unused variable 'tmp_ptr' [-Wunused-variable]
pipe_test.c:185:46: warning: unused variable 'queue_empty' [-Wunused-variable]
```
#### doxygen ####
```
globus_ftp_control.h:594: warning: The following parameter of globus_ftp_control_auth_callback_t(void *callback_arg, struct globus_ftp_control_handle_s *handle, globus_object_t *error, globus_ftp_control_auth_info_t *auth_result) is not documented:
  parameter 'error'
globus_ftp_control.h:1010: warning: argument 'result' of command @param is not found in the argument list of globus_ftp_control_server_callback_t(void *callback_arg, struct globus_ftp_control_server_s *server_handle, globus_object_t *error)
globus_ftp_control.h:1010: warning: The following parameter of globus_ftp_control_server_callback_t(void *callback_arg, struct globus_ftp_control_server_s *server_handle, globus_object_t *error) is not documented:
  parameter 'error'
```
### globus-gass-copy ###
```
globus_gass_copy_glob.c:529:34: warning: comparison between pointer and zero character constant [-Wpointer-compare]
globus_gass_copy_glob.c:945:41: warning: variable 'filename' set but not used [-Wunused-but-set-variable]
globus_url_copy.c:3487:20: warning: comparison between pointer and zero character constant [-Wpointer-compare]
globus_url_copy.c:3762:28: warning: comparison between pointer and zero character constant [-Wpointer-compare]
```
#### doxygen ####
```
globus_gass_copy.h:644: warning: argument 'stat' of command @param is not found in the argument list of globus_gass_copy_glob_entry_cb_t(const char *url, const globus_gass_copy_glob_stat_t *info_stat, void *user_arg)
globus_gass_copy.h:644: warning: The following parameter of globus_gass_copy_glob_entry_cb_t(const char *url, const globus_gass_copy_glob_stat_t *info_stat, void *user_arg) is not documented:
  parameter 'info_stat'
```
### globus-gass-server-ez ###
```
globus_gass_server_ez.c:352:12: warning: variable 'subjectname' set but not used [-Wunused-but-set-variable]
globus_gass_server_ez.c:455:18: warning: 'flags' may be used uninitialized [-Wmaybe-uninitialized]
```
### globus-gass-transfer ###
```
globus_gass_transfer_http.c:2092:12: warning: 'rc' may be used uninitialized [-Wmaybe-uninitialized]
```
#### doxygen ####
```
globus_gass_transfer_proto.h:92: warning: argument 'bytes_length' of command @param is not found in the argument list of globus_gass_transfer_proto_send_t(globus_gass_transfer_request_proto_t *proto, globus_gass_transfer_request_t request, globus_byte_t *bytes, globus_size_t send_length, globus_bool_t last_data)
globus_gass_transfer_proto.h:92: warning: The following parameter of globus_gass_transfer_proto_send_t(globus_gass_transfer_request_proto_t *proto, globus_gass_transfer_request_t request, globus_byte_t *bytes, globus_size_t send_length, globus_bool_t last_data) is not documented:
  parameter 'send_length'
```
### globus-gatekeeper ###
```
/usr/include/bits/stdio2.h:105:10: warning: 'rc' may be used uninitialized [-Wmaybe-uninitialized]
globus_gatekeeper_utils.c:405:17: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
globus_gatekeeper_utils.c:415:9: warning: implicit declaration of function 'initgroups'; did you mean 'getgroups'? [-Wimplicit-function-declaration]
globus_gatekeeper_utils.c:405:17: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
globus_gatekeeper_utils.c:415:9: warning: implicit declaration of function 'initgroups'; did you mean 'getgroups'? [-Wimplicit-function-declaration]
globus_gatekeeper.c:2222:29: warning: passing argument 2 to 'restrict'-qualified parameter aliases with argument 4 [-Wrestrict]
globus_gatekeeper.c:1496:9: warning: 'strncpy' specified bound 256 equals destination size [-Wstringop-truncation]
```
### globus-gram-client ###

#### doxygen ####
```
globus_gram_client.c:337: warning: documented empty return type of globus_gram_client_debug
```
### globus-gram-client-tools ###
```
globusrun.c:365:40: warning: variable 'ignore_ctrlc' set but not used [-Wunused-but-set-variable]
```
### globus-gram-job-manager ###
```
globus_gram_job_manager_config.c:64:41: warning: unused variable 'tmp' [-Wunused-variable]
globus_gram_job_manager.c:1043:5: warning: 'strncpy' specified bound 64 equals destination size [-Wstringop-truncation]
globus_gram_job_manager.c:1484:17: warning: 'ref' may be used uninitialized [-Wmaybe-uninitialized]
globus_gram_job_manager_request.c:3963:1: warning: 'globus_l_gram_check_position' defined but not used [-Wunused-function]
globus_gram_job_manager_staging.c:370:41: warning: variable 'from_cached' set but not used [-Wunused-but-set-variable]
globus_gram_job_manager_staging.c:544:16: warning: 'list' may be used uninitialized [-Wmaybe-uninitialized]
globus_gram_job_manager_seg.c:1416:30: warning: 'event_stamp' may be used uninitialized [-Wmaybe-uninitialized]
globus_gram_job_manager_seg.c:1422:16: warning: 'terminated_normally' may be used uninitialized [-Wmaybe-uninitialized]
globus_gram_job_manager_seg.c:1414:29: warning: 'subproc' may be used uninitialized [-Wmaybe-uninitialized]
globus_gram_job_manager_seg.c:1414:29: warning: 'proc' may be used uninitialized [-Wmaybe-uninitialized]
globus_gram_job_manager_seg.c:1414:29: warning: 'cluster' may be used uninitialized [-Wmaybe-uninitialized]
globus_gram_job_manager_seg.c:1400:9: warning: 'event_type_number' may be used uninitialized [-Wmaybe-uninitialized]
logging.c:59:41: warning: variable 'nowtm' set but not used [-Wunused-but-set-variable]
globus_gram_job_manager_state.c:158:41: warning: variable 'save_jobmanager_state' set but not used [-Wunused-but-set-variable]
globus_gram_job_manager_state.c:157:41: warning: variable 'save_status' set but not used [-Wunused-but-set-variable]
globus_gram_job_manager_state.c:1649:5: warning: enumeration value 'GLOBUS_GRAM_JOB_MANAGER_STATE_FILE_CLEAN_UP' not handled in switch [-Wswitch]
globus_gram_job_manager_state.c:1649:5: warning: enumeration value 'GLOBUS_GRAM_JOB_MANAGER_STATE_SCRATCH_CLEAN_UP' not handled in switch [-Wswitch]
globus_gram_job_manager_state.c:1649:5: warning: enumeration value 'GLOBUS_GRAM_JOB_MANAGER_STATE_CACHE_CLEAN_UP' not handled in switch [-Wswitch]
globus_gram_job_manager_state.c:1649:5: warning: enumeration value 'GLOBUS_GRAM_JOB_MANAGER_STATE_DONE' not handled in switch [-Wswitch]
globus_gram_job_manager_state.c:1649:5: warning: enumeration value 'GLOBUS_GRAM_JOB_MANAGER_STATE_FAILED_CLOSE_OUTPUT' not handled in switch [-Wswitch]
globus_gram_job_manager_state.c:1649:5: warning: enumeration value 'GLOBUS_GRAM_JOB_MANAGER_STATE_FAILED_TWO_PHASE_COMMITTED' not handled in switch [-Wswitch]
globus_gram_job_manager_state.c:1649:5: warning: enumeration value 'GLOBUS_GRAM_JOB_MANAGER_STATE_FAILED_FILE_CLEAN_UP' not handled in switch [-Wswitch]
globus_gram_job_manager_state.c:1649:5: warning: enumeration value 'GLOBUS_GRAM_JOB_MANAGER_STATE_FAILED_SCRATCH_CLEAN_UP' not handled in switch [-Wswitch]
globus_gram_job_manager_state.c:1649:5: warning: enumeration value 'GLOBUS_GRAM_JOB_MANAGER_STATE_FAILED_CACHE_CLEAN_UP' not handled in switch [-Wswitch]
globus_gram_job_manager_state.c:1649:5: warning: enumeration value 'GLOBUS_GRAM_JOB_MANAGER_STATE_FAILED_DONE' not handled in switch [-Wswitch]
globus_gram_job_manager_state.c:1649:5: warning: enumeration value 'GLOBUS_GRAM_JOB_MANAGER_STATE_STOP' not handled in switch [-Wswitch]
globus_gram_job_manager_state.c:1649:5: warning: enumeration value 'GLOBUS_GRAM_JOB_MANAGER_STATE_TWO_PHASE_QUERY1' not handled in switch [-Wswitch]
globus_gram_job_manager_state.c:1649:5: warning: enumeration value 'GLOBUS_GRAM_JOB_MANAGER_STATE_TWO_PHASE_QUERY2' not handled in switch [-Wswitch]
globus_gram_job_manager_state.c:1380:9: warning: 'major_status' may be used uninitialized [-Wmaybe-uninitialized]
main.c:908:9: warning: 'strncpy' specified bound 64 equals destination size [-Wstringop-truncation]
startup_socket.c:1450:25: warning: 'sent_fds' may be used uninitialized [-Wmaybe-uninitialized]
stdio-update-after-failure-test.c:300:1: warning: label 'still_streaming_check_failed' defined but not used [-Wunused-label]
stdio-update-after-failure-test.c:299:1: warning: label 'still_streaming_check_failed2' defined but not used [-Wunused-label]
stdio-update-after-failure-test.c:298:1: warning: label 'incorrect_size_error' defined but not used [-Wunused-label]
stdio-update-after-failure-test.c:297:1: warning: label 'commit_end_failed' defined but not used [-Wunused-label]
restart-to-new-url-test.c:437:1: warning: label 'done' defined but not used [-Wunused-label]
```
### globus-gram-job-manager-fork ###
```
seg_fork_module.c:201:41: warning: variable 'save_errno' set but not used [-Wunused-but-set-variable]
/usr/include/globus/globus_debug.h:164:5: warning: 'save_errno' may be used uninitialized [-Wmaybe-uninitialized]
```
### globus-gram-job-manager-sge ###
```
seg_sge_module.c:231:9: warning: implicit declaration of function 'setenv'; did you mean 'getenv'? [-Wimplicit-function-declaration]
seg_sge_module.c:395:32: warning: implicit declaration of function 'strdup' [-Wimplicit-function-declaration]
seg_sge_module.c:395:32: warning: incompatible implicit declaration of built-in function 'strdup' [-Wbuiltin-declaration-mismatch]
seg_sge_module.c:404:32: warning: incompatible implicit declaration of built-in function 'strdup' [-Wbuiltin-declaration-mismatch]
seg_sge_module.c:486:1: warning: label 'free_sge_root' defined but not used [-Wunused-label]
```
### globus-gridftp-server ###
```
globus_gridftp_server_file.c:1126:53: warning: unused variable 'key' [-Wunused-variable]
globus_gridftp_server_file.c:1125:53: warning: unused variable 'h' [-Wunused-variable]
globus_gridftp_server_file.c:1189:27: warning: the comparison will always evaluate as 'true' for the address of 'd_name' will never be NULL [-Waddress]
globus_gridftp_server_file.c:1256:1: warning: label 'error_stat2' defined but not used [-Wunused-label]
globus_gridftp_server_file.c:1980:41: warning: unused variable 'freq' [-Wunused-variable]
globus_gridftp_server_file.c:1259:5: warning: 'dir' may be used uninitialized [-Wmaybe-uninitialized]
globus_gridftp_server_remote.c:391:41: warning: variable 'num_nodes' set but not used [-Wunused-but-set-variable]
globus_gridftp_server_remote.c:985:25: warning: 'list' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_log.c:88:41: warning: unused variable 'result' [-Wunused-variable]
globus_i_gfs_log.c:372:41: warning: unused variable 'list' [-Wunused-variable]
globus_i_gfs_embed.c:276:5: warning: 'handle' is used uninitialized [-Wuninitialized]
gfs_gfork_master.c:1571:5: warning: 'strncpy' specified bound 108 equals destination size [-Wstringop-truncation]
gfs_gfork_master.c:2054:20: warning: 'val' may be used uninitialized [-Wmaybe-uninitialized]
gfs_dynbe_client.c:213:5: warning: 'strncpy' specified bound 108 equals destination size [-Wstringop-truncation]
gfs_dynbe_client.c:273:5: warning: 'result' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_config.c:1884:41: warning: variable 'longflag' set but not used [-Wunused-but-set-variable]
globus_i_gfs_config.c:1883:41: warning: variable 'shortflag' set but not used [-Wunused-but-set-variable]
globus_i_gfs_config.c:2004:41: warning: variable 'longflag' set but not used [-Wunused-but-set-variable]
globus_i_gfs_config.c:2003:41: warning: variable 'shortflag' set but not used [-Wunused-but-set-variable]
globus_i_gfs_ipc.c:4936:16: warning: 'error_state' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_ipc.c:4419:17: warning: 'data_arg' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_ipc.c:4414:17: warning: 'data_info' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_ipc.c:4404:17: warning: 'cmd_info' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_ipc.c:4397:17: warning: 'trans_info' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_ipc.c:4378:17: warning: 'stat_info' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_ipc.c:4371:17: warning: 'user_buffer_type' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_ipc.c:4371:17: warning: 'user_buffer_length' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_ipc.c:4371:17: warning: 'user_buffer' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_data.c:1128:5: warning: enumeration value 'GLOBUS_L_GFS_DATA_HANDLE_INUSE' not handled in switch [-Wswitch]
globus_i_gfs_data.c:1322:45: warning: unused variable 'tmp_path' [-Wunused-variable]
globus_i_gfs_data.c:2916:41: warning: variable 'session_info' set but not used [-Wunused-but-set-variable]
globus_i_gfs_data.c:5159:41: warning: unused variable 'driver' [-Wunused-variable]
globus_i_gfs_data.c:5157:41: warning: unused variable 'rc' [-Wunused-variable]
globus_i_gfs_data.c:5521:31: warning: pointer targets in assignment from 'gid_t *' {aka 'unsigned int *'} to 'int *' differ in signedness [-Wpointer-sign]
globus_i_gfs_data.c:7624:41: warning: variable 'old_state_dbg' set but not used [-Wunused-but-set-variable]
globus_i_gfs_data.c:9738:41: warning: variable 'last_state' set but not used [-Wunused-but-set-variable]
globus_i_gfs_data.c:11918:41: warning: unused variable 'result' [-Wunused-variable]
globus_i_gfs_data.c:12307:41: warning: unused variable 'code' [-Wunused-variable]
globus_i_gfs_data.c:13468:41: warning: unused variable 'result' [-Wunused-variable]
globus_i_gfs_data.c:2494:1: warning: 'globus_l_gfs_data_decode_passed_cred' defined but not used [-Wunused-function]
globus_i_gfs_data.c:778:17: warning: 'D' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_data.c:5787:22: warning: 'parsed_driver_string' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_data.c:5687:27: warning: 'prog' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_data.c:5086:54: warning: 'c' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_data.c:1736:48: warning: 'alias_ent' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_data.c:7849:13: warning: 'hybrid_op' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_data.c:8715:5: warning: 'op' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_data.c:8906:5: warning: 'op' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_data.c:9380:5: warning: 'result' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_data.c:14835:15: warning: 'next_line' may be used uninitialized [-Wmaybe-uninitialized]
globus_i_gfs_data.c:6875:5: warning: 'action' may be used uninitialized [-Wmaybe-uninitialized]
error_response_test.c:222:41: warning: unused variable 'result' [-Wunused-variable]
```
#### other fixes ####
```
Fix unbalanced mutex lock/unlock
```
### globus-gridftp-server-control ###
```
globus_gridftp_server_control_accessors.c:50:45: warning: variable 'i_server' set but not used [-Wunused-but-set-variable]
globus_gridftp_server_control_commands.c:1092:45: warning: variable 'server_handle' set but not used [-Wunused-but-set-variable]
globus_gridftp_server_control_commands.c:1653:5: warning: 'msg' may be used uninitialized [-Wmaybe-uninitialized]
globus_xio_gssapi_ftp.c:622:64: warning: 'c' may be used uninitialized [-Wmaybe-uninitialized]
globus_xio_gssapi_ftp.c:554:18: warning: 'D' may be used uninitialized [-Wmaybe-uninitialized]
globus_xio_gssapi_ftp.c:1450:27: warning: 'complete' may be used uninitialized [-Wmaybe-uninitialized]
/usr/include/globus/globus_libc.h:229:28: warning: 'msg' may be used uninitialized [-Wmaybe-uninitialized]
globus_gridftp_server_control.c:4687:23: warning: format '%s' expects argument of type 'char *', but argument 4 has type 'void *' [-Wformat=]
globus_gridftp_server_control.c:1999:12: warning: 'res' may be used uninitialized [-Wmaybe-uninitialized]
```
### globus-gsi-proxy-core ###
```
proxy-handle-compat-test.c:77:41: warning: unused variable 'handle' [-Wunused-variable]
proxy-handle-compat-test.c:68:20: warning: 'X509_EXTENSION_cmp' defined but not used [-Wunused-function]
proxy-handle-compat-test.c:67:20: warning: 'X509_REQ_cmp' defined but not used [-Wunused-function]
proxy-handle-test.c:88:41: warning: unused variable 'result' [-Wunused-variable]
proxy-handle-test.c:1066:41: warning: unused variable 'extensions' [-Wunused-variable]
proxy-handle-test.c:1064:41: warning: unused variable 'handle' [-Wunused-variable]
proxy-handle-test.c:1243:41: warning: unused variable 'handle' [-Wunused-variable]
proxy-handle-test.c:1492:1: warning: label 'no_handle' defined but not used [-Wunused-label]
```
### globus-gsi-sysconfig ###
```
system-config-test.c:158:41: warning: unused variable 'ca_name_string' [-Wunused-variable]
system-config-test.c:157:41: warning: unused variable 'signing_policy_filename' [-Wunused-variable]
```
### globus-gssapi-error ###

#### doxygen ####
```
globus_error_gssapi.c:176: warning: documented empty return type of globus_error_gssapi_set_major_status
```
### globus-scheduler-event-generator ###
```
seg_api_test.c:67:9: warning: passing argument 1 of 'globus_scheduler_event_generator_set_event_handler' from incompatible pointer type [-Wincompatible-pointer-types]
globus_scheduler_event_generator_stdout.c:293:13: warning: pointer targets in passing argument 2 of 'globus_xio_register_read' differ in signedness [-Wpointer-sign]
globus_scheduler_event_generator_stdout.c:428:42: warning: pointer targets in passing argument 1 of 'globus_l_seg_register_write' differ in signedness [-Wpointer-sign]
globus_scheduler_event_generator_stdout.c:453:17: warning: pointer targets in passing argument 2 of 'globus_xio_register_read' differ in signedness [-Wpointer-sign]
```
### globus-xio ###
```
globus_xio_http_header_info.c:182:37: warning: passing argument 1 of 'globus_libc_scan_off_t' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
globus_xio_http_transform.c:1494:12: warning: 'result' may be used uninitialized [-Wmaybe-uninitialized]
globus_xio_http_transform.c:1828:12: warning: 'result' may be used uninitialized [-Wmaybe-uninitialized]
globus_xio_tcp_driver.c:1429:51: warning: '__snprintf_chk' output may be truncated before the last format character [-Wformat-truncation=]
globus_xio_telnet.c:462:39: warning: 'dest_attr' may be used uninitialized [-Wmaybe-uninitialized]
globus_xio_telnet.c:462:39: warning: 'dest_attr' may be used uninitialized [-Wmaybe-uninitialized]
globus_xio_telnet.c:462:39: warning: 'dest_attr' may be used uninitialized [-Wmaybe-uninitialized]
globus_xio_udp_driver.c:1023:51: warning: '__snprintf_chk' output may be truncated before the last format character [-Wformat-truncation=]
version.h:18:18: warning: 'local_version' defined but not used [-Wunused-variable]
globus_xio_pass.c:400:41: warning: variable 'handle' set but not used [-Wunused-but-set-variable]
globus_xio_driver.c:256:41: warning: variable 'context' set but not used [-Wunused-but-set-variable]
globus_xio_driver.c:527:41: warning: variable 'context' set but not used [-Wunused-but-set-variable]
globus_xio_driver.c:526:41: warning: variable 'my_context' set but not used [-Wunused-but-set-variable]
globus_xio_driver.c:522:41: warning: variable 'op_type' set but not used [-Wunused-but-set-variable]
globus_xio_driver.c:600:41: warning: variable 'context' set but not used [-Wunused-but-set-variable]
globus_xio_driver.c:599:41: warning: variable 'my_context' set but not used [-Wunused-but-set-variable]
globus_xio_driver.c:595:41: warning: variable 'op_type' set but not used [-Wunused-but-set-variable]
globus_xio_driver.c:873:41: warning: variable 'my_context' set but not used [-Wunused-but-set-variable]
globus_xio_driver.c:872:41: warning: variable 'context' set but not used [-Wunused-but-set-variable]
globus_xio_smtp.c:421:41: warning: variable 'info' set but not used [-Wunused-but-set-variable]
globus_xio_smtp.c:392:12: warning: 'res' is used uninitialized [-Wuninitialized]
globus_xio_smtp.c:431:12: warning: 'res' is used uninitialized [-Wuninitialized]
globus_xio_smtp.c:344:12: warning: 'res' may be used uninitialized [-Wmaybe-uninitialized]
close_barrier2_test.c:145:45: warning: unused variable 'end_time' [-Wunused-variable]
cancel_test.c:189:45: warning: unused variable 'opt_offset' [-Wunused-variable]
framework_test.c:55:49: warning: variable 'info' set but not used [-Wunused-but-set-variable]
http_get_test.c:531:41: warning: variable 'to_read' set but not used [-Wunused-but-set-variable]
http_post_test.c:582:41: warning: variable 'to_read' set but not used [-Wunused-but-set-variable]
http_pingpong_test.c:288:12: warning: 'rc' may be used uninitialized [-Wmaybe-uninitialized]
http_put_test.c:503:41: warning: variable 'to_read' set but not used [-Wunused-but-set-variable]
```
#### doxygen ####
```
globus_xio.h:504: warning: argument 'arg' of command @param is not found in the argument list of globus_xio_timeout_callback_t(globus_xio_handle_t handle, globus_xio_operation_type_t type, void *user_arg)
globus_xio.h:504: warning: The following parameter of globus_xio_timeout_callback_t(globus_xio_handle_t handle, globus_xio_operation_type_t type, void *user_arg) is not documented:
  parameter 'user_arg'
globus_xio_driver.h:386: warning: argument 'driver_attr' of command @param is not found in the argument list of globus_xio_driver_attr_cntl_t(void *attr, int cmd, va_list ap)
globus_xio_driver.h:386: warning: The following parameter of globus_xio_driver_attr_cntl_t(void *attr, int cmd, va_list ap) is not documented:
  parameter 'attr'
globus_xio_driver.h:794: warning: argument 'driver_specific_handle' of command @param is not found in the argument list of globus_xio_driver_close_t(void *driver_handle, void *driver_attr, globus_xio_operation_t op)
globus_xio_driver.h:794: warning: The following parameter of globus_xio_driver_close_t(void *driver_handle, void *driver_attr, globus_xio_operation_t op) is not documented:
  parameter 'driver_handle'
globus_xio_driver.h:861: warning: argument 'driver_handle' of command @param is not found in the argument list of globus_xio_driver_read_t(void *driver_specific_handle, const globus_xio_iovec_t *iovec, int iovec_count, globus_xio_operation_t op)
globus_xio_driver.h:861: warning: The following parameter of globus_xio_driver_read_t(void *driver_specific_handle, const globus_xio_iovec_t *iovec, int iovec_count, globus_xio_operation_t op) is not documented:
  parameter 'driver_specific_handle'
globus_xio_driver.h:473: warning: argument 'server' of command @param is not found in the argument list of globus_xio_driver_server_destroy_t(void *driver_server)
globus_xio_driver.h:1011: warning: argument 'driver_handle' of command @param is not found in the argument list of globus_xio_driver_write_t(void *driver_specific_handle, const globus_xio_iovec_t *iovec, int iovec_count, globus_xio_operation_t op)
globus_xio_driver.h:1011: warning: The following parameter of globus_xio_driver_write_t(void *driver_specific_handle, const globus_xio_iovec_t *iovec, int iovec_count, globus_xio_operation_t op) is not documented:
  parameter 'driver_specific_handle'
```
### globus-xio-gridftp-driver ###
```
globus_xio_gridftp_driver.c:820:16: warning: 'error_info' may be used uninitialized [-Wmaybe-uninitialized]
globus_xio_gridftp_driver.c:1131:9: warning: 'requestor_length' may be used uninitialized [-Wmaybe-uninitialized]
globus_xio_gridftp_driver.c:1125:32: warning: 'requestor_offset' may be used uninitialized [-Wmaybe-uninitialized]
globus_xio_gridftp_driver.c:1125:32: warning: 'requestor_op' may be used uninitialized [-Wmaybe-uninitialized]
globus_gridftp_driver_test.c:235:14: warning: 'filename' may be used uninitialized [-Wmaybe-uninitialized]
```
### globus-xio-gridftp-multicast ###
```
globus_xio_gridftp_multicast_driver.c:300:21: warning: comparison between pointer and zero character constant [-Wpointer-compare]
globus_xio_gridftp_multicast_driver.c:266:41: warning: variable 'len' set but not used [-Wunused-but-set-variable]
globus_xio_gridftp_multicast_driver.c:246:19: warning: 'ftp_handle' may be used uninitialized [-Wmaybe-uninitialized]
globus_xio_gridftp_multicast_driver.c:1320:15: warning: 'wait_for' may be used uninitialized [-Wmaybe-uninitialized]
```
### myproxy ###
```
gssapi.c:298:40: warning: passing argument 3 of '_plug_buf_alloc' from incompatible pointer type [-Wincompatible-pointer-types]
gssapi.c:322:44: warning: passing argument 3 of '_plug_buf_alloc' from incompatible pointer type [-Wincompatible-pointer-types]
gssapi.c:340:40: warning: passing argument 3 of '_plug_buf_alloc' from incompatible pointer type [-Wincompatible-pointer-types]
gssapi.c:367:44: warning: passing argument 3 of '_plug_buf_alloc' from incompatible pointer type [-Wincompatible-pointer-types]
gssapi.c:383:40: warning: passing argument 3 of '_plug_buf_alloc' from incompatible pointer type [-Wincompatible-pointer-types]
gssapi.c:89:19: warning: 'plugin_id' defined but not used [-Wunused-const-variable=]
gsi_socket.c:636:33: warning: unused variable 'target_name_type' [-Wunused-variable]
gsi_socket.c:635:33: warning: unused variable 'target_name' [-Wunused-variable]
myproxy.c:854:16: warning: unused variable 'rc' [-Wunused-variable]
myproxy.c:850:21: warning: unused variable 'buf' [-Wunused-variable]
myproxy.c:2847:23: warning: '*' in boolean context, suggest '&&' instead [-Wint-in-bool-context]
myproxy_server_config.c:1347:22: warning: the comparison will always evaluate as 'false' for the address of 'name' will never be NULL [-Waddress]
vomsclient.c:307:5: warning: 'strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
vomsclient.c:274:5: warning: 'strncpy' specified bound depends on the length of the source argument [-Wstringop-truncation]
vomsclient.c:226:5: warning: 'strncpy' specified bound depends on the length of the source argument [-Wstringop-truncation]
ssl_utils.c:15:37: warning: left-hand operand of comma expression has no effect [-Wunused-value]
myproxy_alcf.c:98:22: warning: variable 'creds' set but not used [-Wunused-but-set-variable]
myproxy_server.c:1948:20: warning: the comparison will always evaluate as 'true' for the address of 'passphrase' will never be NULL [-Waddress]
myproxy_server.c:2258:71: warning: the comparison will always evaluate as 'true' for the address of 'passphrase' will never be NULL [-Waddress]
```
