### PR TITLE
Enable GHA CI builds also for pushes to the master branch

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -2,6 +2,8 @@ name: Build/Test/Deploy
 
 on:
   push:
+    branches:
+      - master
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
       - v[0-9]+.[0-9]+.[0-9]+.[0-9]+


### PR DESCRIPTION
This should enable GHA CI builds after merging pull requests. Before this change GHA CI builds only happened when:
* a tag ([with special format](https://github.com/gridcf/gct/blob/41c255119dcbdbd8bd12d28d8f187df96bc0ec27/.github/workflows/build-test-deploy.yml#L5-L7)) was created (and pushed)
* a pull request was created