### PR TITLE
Can't use non-existing or non-accessible files as source for random data

### DIFF
--- a/gsi/cert_utils/source/configure.ac
+++ b/gsi/cert_utils/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gsi_cert_utils], [10.9], [https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gsi_cert_utils], [10.10], [https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gsi/cert_utils/source/programs/grid-cert-request.in
+++ b/gsi/cert_utils/source/programs/grid-cert-request.in
@@ -753,7 +753,7 @@ create_certs () {
 
     if test ! -z "${INTERACTIVE}" ; then
         "$openssl" req -new -keyout ${KEY_FILE} -out ${REQ_OUTPUT} \
-            -rand ${RAND_TEMP}:/var/adm/wtmp:/var/log/messages \
+            -rand ${RAND_TEMP} \
             -config ${used_config} ${NO_DES}
         RET=$?
         rm -f ${RAND_TEMP}
@@ -761,7 +761,7 @@ create_certs () {
         create_input_file "${COMMON_NAME}" "${used_config}" > ${REQ_INPUT}
 
         "$openssl" req -new -keyout ${KEY_FILE} \
-              -rand ${RAND_TEMP}:/var/adm/wtmp:/var/log/messages \
+              -rand ${RAND_TEMP} \
               -out ${REQ_OUTPUT} -config ${used_config} \
               ${NO_DES} < ${REQ_INPUT} 
         RET=$?

--- a/packaging/debian/globus-gsi-cert-utils/debian/changelog.in
+++ b/packaging/debian/globus-gsi-cert-utils/debian/changelog.in
@@ -1,3 +1,10 @@
+globus-gsi-cert-utils (10.10-1+gct.@distro@) @distro@; urgency=medium
+
+  * Can't use non-existing or non-accessible files as source for random
+    data
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Sat, 07 May 2022 06:31:59 +0200
+
 globus-gsi-cert-utils (10.9-1+gct.@distro@) @distro@; urgency=medium
 
   * Add missing comma

--- a/packaging/fedora/globus-gsi-cert-utils.spec
+++ b/packaging/fedora/globus-gsi-cert-utils.spec
@@ -3,7 +3,7 @@
 Name:		globus-gsi-cert-utils
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	10.9
+Version:	10.10
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Cert Utils Library
 
@@ -180,6 +180,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Sat May 07 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.10-1
+- Can't use non-existing or non-accessible files as source for random data
+
 * Mon Apr 11 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.9-1
 - Add missing comma
 


### PR DESCRIPTION
$ grid-cert-request --dir tmp
Enter your name, e.g., John Smith: NN
A certificate request and private key is being created.
You will be asked to enter a PEM pass phrase.
This pass phrase is akin to your account password,
and is used to protect your key file.
If you forget your pass phrase, you will need to
obtain a new certificate.

Can't load /var/adm/wtmp into RNG
80EB3915197F0000:error:12000079:random number generator:RAND_load_file:Cannot open file:crypto/rand/randfile.c:106:Filename=/var/adm/wtmp
Can't load /var/log/messages into RNG
80EB3915197F0000:error:12000079:random number generator:RAND_load_file:Cannot open file:crypto/rand/randfile.c:106:Filename=/var/log/messages
Error number 1 was returned by
   /usr/bin/openssl