### PR TITLE
CI changes

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -22,6 +22,10 @@ jobs:
             components: 'myproxy,ssh'
           - image: 'quay.io/centos/centos:stream9'
             components: 'gram5'
+          - image: 'rockylinux:9'
+            components: 'myproxy,ssh'
+          - image: 'rockylinux:9'
+            components: 'gram5'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -35,7 +39,8 @@ jobs:
         run: travis-ci/setup_tasks.sh
         
       - name: build source tarballs and srpms
-        # Only run this step for the centos:centos7 case and for only one component selection
+        # Only run this step for the centos:centos7 case and for only one component selection,
+        # it still builds **all** source tarballs and SRPMs
         if: |
           contains(matrix.image , 'centos:centos7') &&
           contains(matrix.components , 'udt,myproxy,ssh')
@@ -46,9 +51,12 @@ jobs:
       
       # SSH key recipe from https://www.webfactory.de/blog/use-ssh-key-for-private-repositories-in-github-actions
       - name: Establish ssh and upload source tarballs
-        # Only run this step for the centos:centos7 case
+        # Only run this step for the centos:centos7 case and
+        # for only one component selection and
+        # only when a tag was created
         if: |
           contains(matrix.image , 'centos:centos7') &&
+          contains(matrix.components , 'udt,myproxy,ssh') &&
           contains(github.ref , 'refs/tags/')
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
@@ -56,5 +64,5 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
-          ssh-add - <<< "${{ secrets.ID_GCTUPLOADER }}"
+          ssh-add - <<< "${{ secrets.ID_GRIDCF_UPLOADER }}"
           travis-ci/upload_source_tarballs.sh ${{ github.repository_owner }}

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -13,6 +13,8 @@ jobs:
   run-scripts:
     runs-on: ubuntu-latest
     strategy:
+      # Don't cancel the remaining running jobs if some job(s) fail(s)
+      fail-fast: false
       matrix:
         image: ['centos:centos7', 'rockylinux:8', 'quay.io/centos/centos:stream8']
         components: ['udt,myproxy,ssh', 'gram5']
@@ -39,24 +41,23 @@ jobs:
         run: travis-ci/setup_tasks.sh
         
       - name: build source tarballs and srpms
-        # Only run this step for the centos:centos7 case and for only one component selection,
+        # Run this step for all OS cases but for only one component selection each,
         # it still builds **all** source tarballs and SRPMs
         if: |
-          contains(matrix.image , 'centos:centos7') &&
-          contains(matrix.components , 'udt,myproxy,ssh')
+          contains(matrix.components , 'gram5')
         env:
-          IMAGE: centos:centos7
+          IMAGE: ${{ matrix.image }}
           TASK: srpms
         run: travis-ci/setup_tasks.sh
       
       # SSH key recipe from https://www.webfactory.de/blog/use-ssh-key-for-private-repositories-in-github-actions
       - name: Establish ssh and upload source tarballs
         # Only run this step for the centos:centos7 case and
-        # for only one component selection and
+        # for only one component selection (must be the same as for the previous step!) and
         # only when a tag was created
         if: |
           contains(matrix.image , 'centos:centos7') &&
-          contains(matrix.components , 'udt,myproxy,ssh') &&
+          contains(matrix.components , 'gram5') &&
           contains(github.ref , 'refs/tags/')
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,29 @@
 
 # Also, the following gram tests failed for all fedora versions:
 #   nonblocking-register-test.pl, register-callback-test.pl, register-test.pl
-arch:
+os: linux
+dist: focal
+language: ruby
+# As per [1] explicitly included builds inherit the first value in an array.
+# [1]: https://docs.travis-ci.com/user/multi-cpu-architectures#example-multi-architecture-build-matrix
+# Hence the desired arch needs to be specified for each job additionally
+# below.
+#arch:
   # Disabled for now
   #- amd64
   # Handled via partner queue, uncharged
-  - ppc64le
+  #- ppc64le
   #- arm64
 jobs:
   include:
 
     - &run_tests
       # Template; subsequent uses modify 'env'
+      arch:
+        - ppc64le
       env:
         - IMAGE=centos:centos7 TASK=tests COMPONENTS=udt,myproxy,ssh
       stage: test
-      sudo: required
       services:
         - docker
 
@@ -30,6 +38,19 @@ jobs:
 
       script:
       - travis-ci/setup_tasks.sh
+
     - <<: *run_tests
+      arch:
+        - arm64
+
+    - <<: *run_tests
+      arch:
+        - ppc64le
+      env:
+        - IMAGE=centos:centos7 TASK=tests COMPONENTS=gram5
+
+    - <<: *run_tests
+      arch:
+        - arm64
       env:
         - IMAGE=centos:centos7 TASK=tests COMPONENTS=gram5

--- a/travis-ci/run_task_inside_docker.sh
+++ b/travis-ci/run_task_inside_docker.sh
@@ -13,6 +13,7 @@ case $(</etc/redhat-release) in
     CentOS\ Stream*\ 8*) OS=centos-stream-8;;
     CentOS\ Stream*\ 9*) OS=centos-stream-9;;
     Rocky\ Linux*\ 8*) OS=rockylinux8 ;;
+    Rocky\ Linux*\ 9*) OS=rockylinux9 ;;
     *) OS=unknown ;;
 esac
 
@@ -24,6 +25,11 @@ case $OS in
     rockylinux8)
               dnf -y install dnf-plugins-core
               dnf config-manager --set-enabled powertools
+              dnf -y install epel-release
+              ;;
+    rockylinux9)
+              dnf -y install dnf-plugins-core
+              dnf config-manager --set-enabled crb
               dnf -y install epel-release
               ;;
     centos-stream-8)
@@ -52,7 +58,8 @@ if [[ $OS != centos7 ]]; then
 
     # provides `cmp` used by `packaging/git-dirt-filter`
     packages+=(diffutils)
-    if [[ $OS == centos-stream-9 ]]; then
+    if [[ $OS == centos-stream-9 || \
+          $OS == rockylinux9 ]]; then
 
         # also install "zlib zlib-devel" because it's needed for `configure`ing
         # "gridftp/server/src"

--- a/travis-ci/run_task_inside_docker.sh
+++ b/travis-ci/run_task_inside_docker.sh
@@ -9,11 +9,36 @@ COMPONENTS=${3-}
 set -e
 
 case $(</etc/redhat-release) in
-    CentOS*\ 7*) OS=centos7 ;;
-    CentOS\ Stream*\ 8*) OS=centos-stream-8;;
-    CentOS\ Stream*\ 9*) OS=centos-stream-9;;
-    Rocky\ Linux*\ 8*) OS=rockylinux8 ;;
-    Rocky\ Linux*\ 9*) OS=rockylinux9 ;;
+    CentOS*\ 7*)
+
+        OS=centos7
+        release_ver=el7
+        ;;
+
+    CentOS\ Stream*\ 8*)
+
+        OS=centos-stream-8
+        release_ver=el8
+        ;;
+
+    CentOS\ Stream*\ 9*)
+
+        OS=centos-stream-9
+        release_ver=el9
+        ;;
+
+    Rocky\ Linux*\ 8*)
+
+        OS=rockylinux8
+        release_ver=el8
+        ;;
+
+    Rocky\ Linux*\ 9*)
+
+        OS=rockylinux9
+        release_ver=el9
+        ;;
+
     *) OS=unknown ;;
 esac
 
@@ -54,12 +79,11 @@ packages=(gcc gcc-c++ make autoconf automake libtool \
           'perl(URI)' file sudo bison patch curl \
           pam pam-devel libedit libedit-devel)
 
-if [[ $OS != centos7 ]]; then
+if [[ $OS != *7 ]]; then
 
     # provides `cmp` used by `packaging/git-dirt-filter`
     packages+=(diffutils)
-    if [[ $OS == centos-stream-9 || \
-          $OS == rockylinux9 ]]; then
+    if [[ $OS == *9 ]]; then
 
         # also install "zlib zlib-devel" because it's needed for `configure`ing
         # "gridftp/server/src"
@@ -85,24 +109,54 @@ elif [[ $TASK == *rpms ]]; then
     # for globus-gridftp-server:
     packages+=(fakeroot)
     # for globus-xio-udt-driver:
-    packages+=(udt udt-devel glib2-devel libnice-devel gettext-devel libffi-devel)
+    if [[ $OS == *9 ]]; then
+
+        # libnice-devel is not available for CentOS Stream 9 / Rocky Linux 9.
+        #
+        # make_rpms.sh was also updated in this regard.
+        :
+    else
+        packages+=(udt udt-devel glib2-devel libnice-devel gettext-devel libffi-devel)
+    fi
     # for globus-gram-job-manager:
     packages+=(libxml2-devel)
     # for myproxy:
     packages+=(pam-devel voms-devel cyrus-sasl-devel openldap-devel voms-clients initscripts)
     # for globus-net-manager:
-    packages+=(python-devel)
+    if [[ $OS == *7 ]]; then
+
+        packages+=(python-devel)
+    else
+        packages+=(python3-devel)
+    fi
     # for globus-gram-audit:
     packages+=('perl(DBI)')
     # for globus-scheduler-event-generator:
-    packages+=(redhat-lsb-core)
+    if [[ $OS == *9 ]]; then
+
+        # redhat-lsb-core is not available for CentOS Stream 9 / Rocky Linux 9.
+        # But the default is also to not use LSB, so can be ignored.
+        :
+    else
+        packages+=(redhat-lsb-core)
+    fi
     # for myproxy-oauth
-    packages+=(m2crypto mod_ssl mod_wsgi pyOpenSSL python-crypto)
+    if [[ $OS == *7 ]]; then
+
+        packages+=(m2crypto mod_ssl mod_wsgi pyOpenSSL python-crypto)
+    else
+        # Except for mod_ssl above packages are not available on CentOS Stream
+        # 8 / Rocky Linux 8 and upwards.
+        #
+        # make_rpms.sh and make_source_tarballs.sh were also updated in this
+        # regard.
+        :
+    fi
     # for gsi-openssh
     packages+=(pam libedit libedit-devel)
 fi
 
-if [[ $OS == centos7 ]]; then
+if [[ $OS == *7 ]]; then
 	yum -y -d1 install "${packages[@]}"
 else
 	dnf --allowerasing -y -d1 install "${packages[@]}"
@@ -162,7 +216,8 @@ case $TASK in
     srpms)
         make_tarballs
         echo '==========================================================================================='
-        make_srpms .gct
+        # NOTICE: No dashes in the dist string!
+        make_srpms .gct.$release_ver
 
         # copy all the files we want to deploy into one directory b/c
         # can't specify multiple directories in travis
@@ -174,14 +229,9 @@ case $TASK in
     rpms)
         make_tarballs
         echo '==========================================================================================='
-        if [[ $OS == centos6 ]]; then
-            # doesn't support rpmbuild --nocheck
-            nocheck=
-        else
-            # -C = skip unit tests
-            nocheck=-C
-        fi
-        make_rpms $nocheck .gct.$OS
+        # NOTICE: No dashes in the dist string!
+        # -C = skip unit tests
+        make_rpms -C .gct.$release_ver
 
         # copy all the files we want to deploy into one directory b/c
         # can't specify multiple directories in travis
@@ -191,12 +241,10 @@ case $TASK in
         # raise an error).
         # `overwrite: true` in .travis.yml ought to fix that, but doesn't
         # appear to.
-        if [[ $OS == centos6 ]]; then
-            cp -f packaging/rpmbuild/SRPMS/*.rpm package-output/*.tar.gz  \
-                travis_deploy/
-        fi
+        cp -f packaging/rpmbuild/SRPMS/*.rpm package-output/*.tar.gz  \
+              travis_deploy/
         cp -f packaging/rpmbuild/RPMS/noarch/*.rpm packaging/rpmbuild/RPMS/x86_64/*.rpm  \
-            travis_deploy/
+              travis_deploy/
         ;;
     *)
         echo "*** INVALID TASK '$TASK' ***"

--- a/travis-ci/upload_source_tarballs.sh
+++ b/travis-ci/upload_source_tarballs.sh
@@ -7,12 +7,11 @@ set -eux
 
 repo_owner=$1
 
-# also hosts repo.gridcf.org; can't use repo.gridcf.org directly because
-# CloudFlare apparently doesn't properly handle SSH
-upload_server=hcc-osg-repo.unl.edu
+# hosts repo.gridcf.org
+upload_server="repo-gridcf.redir.ops.egi.eu"
 
-# obtained by running "ssh-keyscan hcc-osg-repo.unl.edu"
-hostsig="hcc-osg-repo.unl.edu ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2AIWAVx2KY+GhDab9SdxLTvjjzTiNa4pfHe7TvRZ5O+qZNc4c8sBlsG7OZGZvDLMRjGTKFyjJx3jDVUwaf14DwzQi9rgZxEZgBsRFffLATZqz+DyVN1H9uw215pah9Wh6yzaqMn51y6kqg0kk/ip62cYcXFgLKUNkzV0yz5WFugm5ziROZn01v5o74VdCABTAdlZhviUoObCn+bycXoUGGETY5GZ3muAW6y5LydDTD+2S97qJWGdSW7JBIfcmU7n5dl8MrtYKYwGswOgdUDrLtCp6CdZt/Evr+3NyLp35IhLnwxdkBBlKHPY0jXrGHyemsXa0Hq0PG/Ih5d0M8RMp"
+# obtained by running "repo-gridcf.redir.ops.egi.eu"
+hostsig="repo-gridcf.redir.ops.egi.eu ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN4jPJDFLpljf6pSai/W2yh1/bgvRkfpLf9vvHs6ETYb"
 
 
 echo "$hostsig" > ~/.ssh/known_hosts


### PR DESCRIPTION
This PR implements the following changes:

1. Switchover to new source repo hosted by EGI
2. Use Ubuntu Focal (20.04) as build environment for Travis CI instead of the out-of-date but still default Ubuntu Xenial (16.04), clean up the configuration according to config validation at Travis CI and enable builds on ARM64, too. 
3. Add Rocky Linux 9 as build target for GHA and update secret name for uploads to the source repo
4. Build source tarballs and SRPMs for all OS cases for GHA

no.4 unveiled the following issues:

* "globus-xio-udt-driver" can't be built (also for SRPM) on CentOS Stream 9 and Rocky Linux 9 because "libnice(-devel)" is not (yet) available for these OSes, so (S)RPMs are not built for *9 OS versions, too. Mattias has already opened [a bug about branching and building libnice in EPEL 9](https://bugzilla.redhat.com/show_bug.cgi?id=2033520).

* "myproxy-oauth" can't be built on CentOS Stream 8 and Rocky Linux 8 and upwards as it depends on Python 2.x based dependencies not available for the respective OSes, so neither source tarballs nor (S)RPMs are built for *8 and *9 OS versions. There is also no "myproxy-oauth" package in EPEL or Fedora AFAICS. So this part of the GCT could be (1) dropped when switching from CentOS 7 to an *8 version of the OS as main build target or (2) needs to be ported to Python 3 if kept.

* "globus-scheduler-event-generator" depends on LSB (Linux Standard Base) if available (see https://github.com/gridcf/gct/blob/switchover-to-new-src-repo/gram/jobmanager/scheduler_event_generator/source/configure.ac#L59..#L77 for details) but per default does not actually depend on LSB, so for *9 OS versions which are missing "redhat-lsb-core" the LSB dependency can be safely ignored. The dependency comes from [an init script version that uses LSB init functions](https://github.com/fscheiner/gct/blob/switchover-to-new-src-repo/gram/jobmanager/scheduler_event_generator/source/init/globus-scheduler-event-generator-lsb.in#L56). The "globus-scheduler-event-generator-progs" package in EPEL and Fedora use [a non-LSB init script](https://src.fedoraproject.org/rpms/globus-scheduler-event-generator/blob/rawhide/f/globus-scheduler-event-generator) or [a systemd unit file w/o LSB dependency](https://src.fedoraproject.org/rpms/globus-scheduler-event-generator/blob/rawhide/f/globus-scheduler-event-generator%40.service).

