### PR TITLE
Replace make_time function to work after 2050

### DIFF
--- a/gsi/cert_utils/source/configure.ac
+++ b/gsi/cert_utils/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gsi_cert_utils], [10.10], [https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gsi_cert_utils], [10.11], [https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gsi/cert_utils/source/library/globus_gsi_cert_utils.h
+++ b/gsi/cert_utils/source/library/globus_gsi_cert_utils.h
@@ -130,7 +130,7 @@ globus_module_descriptor_t              globus_i_gsi_cert_utils_module;
 
 globus_result_t
 globus_gsi_cert_utils_make_time(
-    const ASN1_UTCTIME *                ctm,
+    const ASN1_TIME *                   ctm,
     time_t *                            newtime);
 
 globus_result_t

--- a/gsi/credential/source/configure.ac
+++ b/gsi/credential/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gsi_credential],[8.3],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gsi_credential],[8.4],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gsi/credential/source/library/globus_gsi_cred_handle.c
+++ b/gsi/credential/source/library/globus_gsi_cred_handle.c
@@ -397,8 +397,6 @@ globus_gsi_cred_get_lifetime(
     globus_gsi_cred_handle_t            cred_handle,
     time_t *                            lifetime)
 {
-    time_t                              time_now;
-    ASN1_UTCTIME *                      asn1_time;
     globus_result_t                     result;
 
     GLOBUS_I_GSI_CRED_DEBUG_ENTER;
@@ -413,12 +411,7 @@ globus_gsi_cred_get_lifetime(
         goto error_exit;
     }
 
-    asn1_time = ASN1_UTCTIME_new();
-    X509_gmtime_adj(asn1_time, 0);
-    globus_gsi_cert_utils_make_time(asn1_time, &time_now);
-
-    *lifetime = cred_handle->goodtill - time_now;
-    ASN1_UTCTIME_free(asn1_time);
+    *lifetime = cred_handle->goodtill - time(NULL);
 
     result = GLOBUS_SUCCESS;
 

--- a/packaging/debian/globus-gsi-cert-utils/debian/changelog.in
+++ b/packaging/debian/globus-gsi-cert-utils/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gsi-cert-utils (10.11-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix parsing of ASN1 timestamps
+
+ -- Mischa Sallé <msalle@nikhef.nl>  Thu, 19 Jan 2023 14:58:23 +0100
+
 globus-gsi-cert-utils (10.10-1+gct.@distro@) @distro@; urgency=medium
 
   * Can't use non-existing or non-accessible files as source for random

--- a/packaging/debian/globus-gsi-credential/debian/changelog.in
+++ b/packaging/debian/globus-gsi-credential/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gsi-credential (8.4-1+gct.@distro@) @distro@; urgency=medium
+
+  * Greatly simplify getting current time
+
+ -- Mischa Sallé <msalle@nikhef.nl>  Thu, 19 Jan 2023 14:55:00 +0100
+
 globus-gsi-credential (8.3-1+gct.@distro@) @distro@; urgency=medium
 
   * Typo fixes

--- a/packaging/fedora/globus-gsi-cert-utils.spec
+++ b/packaging/fedora/globus-gsi-cert-utils.spec
@@ -3,7 +3,7 @@
 Name:		globus-gsi-cert-utils
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	10.10
+Version:	10.11
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Cert Utils Library
 
@@ -180,6 +180,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Thu Jan 19 2023 Mischa Salle <msalle@nikhef.nl> - 10.11-1
+- Fix parsing of ASN1 timestamps
+
 * Sat May 07 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 10.10-1
 - Can't use non-existing or non-accessible files as source for random data
 

--- a/packaging/fedora/globus-gsi-credential.spec
+++ b/packaging/fedora/globus-gsi-credential.spec
@@ -3,7 +3,7 @@
 Name:		globus-gsi-credential
 %global soname 1
 %global _name %(echo %{name} | tr - _)
-Version:	8.3
+Version:	8.4
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Credential Library
 
@@ -137,6 +137,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.la
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Thu Jan 19 2023 Mischa Salle <msalle@nikhef.nl> - 8.4-1
+- Greatly simplify getting current time
+
 * Fri Aug 20 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 8.3-1
 - Typo fixes
 


### PR DESCRIPTION
By using `ASN1_TIME_diff()` instead of manually parsing the data, we make `globus_gsi_cert_utils_make_time()` a lot simpler and also work for `ASN1_GENERALIZEDTIME` and not just `ASN1_UTCTIME` (i.e. it can use `ASN1_TIME`). `ASN1_TIME_diff()` requires OpenSSL >= 1.0.2.
Also rework `globus_gsi_cred_get_lifetime()` to just use `time(NULL)` to get the current UNIX timestamp which means it no longer needs `globus_gsi_cert_utils_make_time()`.
This fixes issue #208