### PR TITLE
Add missing header file

### DIFF
--- a/gsi_openssh/source/fips_mode_replacement.h
+++ b/gsi_openssh/source/fips_mode_replacement.h
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 
+#ifndef FIPS_MODE_REPLACEMENT_H
+#define FIPS_MODE_REPLACEMENT_H
+
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 /*
- * OpenSSL version 3.0 and up no longer has FIPS_mode().
- * Making a replacement function is not feasible since FIPS would need to be
- * initialized differently in any case.
- * See https://www.openssl.org/docs/manmaster/man7/fips_module.html for details
+ * OpenSSL versions 3.0 and up no longer have FIPS_mode(). To support both
+ * OpenSSL 3.x and older versions for other OSes, we use the replacement
+ * function as shipped by Fedora/RHEL/CentOS in their OpenSSL 3.x packages.
  */
-# define FIPS_mode() 0
-#endif
+# ifndef FIPS_mode
+#  define FIPS_mode() EVP_default_properties_is_fips_enabled(NULL)
+# endif /* FIPS_mode */
+#endif /* openssl */
+
+#endif /* FIPS_MODE_REPLACEMENT_H */

--- a/gsi_openssh/source/kexgex.c
+++ b/gsi_openssh/source/kexgex.c
@@ -34,7 +34,6 @@
 #include <signal.h>
 
 #include "openbsd-compat/openssl-compat.h"
-#include "fips_mode_replacement.h"
 
 #include "sshkey.h"
 #include "cipher.h"

--- a/gsi_openssh/source/kexgexc.c
+++ b/gsi_openssh/source/kexgexc.c
@@ -39,6 +39,7 @@
 #include <signal.h>
 
 #include "openbsd-compat/openssl-compat.h"
+#include "fips_mode_replacement.h"
 
 #include "sshkey.h"
 #include "cipher.h"


### PR DESCRIPTION
Fixes #207

****

Looking at https://github.com/gridcf/gct/actions/runs/3940255855/jobs/6780376794#step:3:13057 this interestingly now also affects our builds on ~Rocky Linux~ CentOS Stream 9 ~(and most likely also CentOS Stream 9)~ - it didn't in the past runs. I don't know why this starts to happen now, maybe a change in the used OpenSSL on these distributions.

****
Corrected: I misread things at first.