### PR TITLE
Remove register qualifier that is incompatible with C++17

### DIFF
--- a/common/source/configure.ac
+++ b/common/source/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.60])
-AC_INIT([globus_common], [18.13], [https://github.com/gridcf/gct/issues])
+AC_INIT([globus_common], [18.14], [https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/common/source/library/globus_libc.h
+++ b/common/source/library/globus_libc.h
@@ -203,13 +203,13 @@ globus_libc_strncasecmp(
     const char *                            s2,
     globus_size_t                           n);
 
-int globus_libc_setenv(register const char *name,
-		       register const char *value,
+int globus_libc_setenv(const char *name,
+		       const char *value,
 		       int rewrite);
-void globus_libc_unsetenv(register const char *name);
+void globus_libc_unsetenv(const char *name);
 
 /* Use getenv instead */
-GLOBUS_DEPRECATED(char *globus_libc_getenv(register const char *name));
+GLOBUS_DEPRECATED(char *globus_libc_getenv(const char *name));
 
 /* Use strerror or strerror_r as needed instead */
 char *globus_libc_system_error_string(int the_error);

--- a/common/source/library/globus_libc_setenv.c
+++ b/common/source/library/globus_libc_setenv.c
@@ -7,8 +7,8 @@
 #endif
 int
 globus_libc_setenv(
-    register const char *name,
-    register const char *value,
+    const char *name,
+    const char *value,
     int rewrite)
 {
 #ifdef _WIN32
@@ -26,7 +26,7 @@ globus_libc_setenv(
 #endif
 }
 
-#ifdef  globus_libc_unsetenv
+#ifdef globus_libc_unsetenv
 #undef globus_libc_unsetenv
 #endif
 void

--- a/packaging/debian/globus-common/debian/changelog.in
+++ b/packaging/debian/globus-common/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-common (18.14-1+gct.@distro@) @distro@; urgency=medium
+
+  * Remove register qualifier that is incompatible with C++ 17
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Thu, 16 Feb 2023 23:45:49 +0100
+
 globus-common (18.13-1+gct.@distro@) @distro@; urgency=medium
 
   * Simplify code

--- a/packaging/fedora/globus-common.spec
+++ b/packaging/fedora/globus-common.spec
@@ -3,7 +3,7 @@
 Name:		globus-common
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	18.13
+Version:	18.14
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Common Library
 
@@ -239,6 +239,9 @@ make %{?_smp_mflags} check VERBOSE=1 NO_EXTERNAL_NET=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Thu Feb 16 2023 Mattias Ellert <mattias.ellert@physics.uu.se> - 18.14-1
+- Remove register qualifier that is incompatible with C++ 17
+
 * Mon Apr 11 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 18.13-1
 - Simplify code
 


### PR DESCRIPTION
~~~
/usr/include/globus/globus_libc.h:206:45: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
  206 | int globus_libc_setenv(register const char *name,
      |                                             ^~~~
/usr/include/globus/globus_libc.h:207:45: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
  207 |                        register const char *value,
      |                                             ^~~~~
/usr/include/globus/globus_libc.h:209:48: warning: ISO C++17 does not allow ‘register’ storage class specifier [-Wregister]
  209 | void globus_libc_unsetenv(register const char *name);
      |                                                ^~~~
~~~
