### PR TITLE
Make library linking survive -Wl,--as-needed

### DIFF
--- a/gram/rsl/source/configure.ac
+++ b/gram/rsl/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_rsl],[11.3],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_rsl],[11.4],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gram/rsl/source/dummy.c
+++ b/gram/rsl/source/dummy.c
@@ -1,1 +1,4 @@
-int globus_i_rsl_assist_dummy_int=0;
+#include "globus_rsl.h"
+int globus_i_rsl_assist_dummy_int(void) {
+    return globus_rsl_is_relation(NULL);
+}

--- a/gram/rsl/source/globus_rsl.c
+++ b/gram/rsl/source/globus_rsl.c
@@ -2491,7 +2491,7 @@ globus_rsl_param_get(globus_rsl_t * ast_node,
     return(0);
 }
 
-int lvl = 0;
+static int lvl = 0;
 
 /* for printing RSL tree */
 #define INDENT(LVL) { \

--- a/packaging/debian/globus-rsl/debian/changelog.in
+++ b/packaging/debian/globus-rsl/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-rsl (11.4-1+gct.@distro@) @distro@; urgency=medium
+
+  * Make library linking survive -Wl,--as-needed
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Tue, 29 Aug 2023 15:21:15 +0200
+
 globus-rsl (11.3-1+gct.@distro@) @distro@; urgency=medium
 
   * Typo fixes

--- a/packaging/fedora/globus-rsl.spec
+++ b/packaging/fedora/globus-rsl.spec
@@ -3,7 +3,7 @@
 Name:		globus-rsl
 %global soname 2
 %global _name %(echo %{name} | tr - _)
-Version:	11.3
+Version:	11.4
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Resource Specification Language Library
 
@@ -142,6 +142,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Tue Aug 29 2023 Mattias Ellert <mattias.ellert@physics.uu.se> - 11.4-1
+- Make library linking survive -Wl,--as-needed
+
 * Fri Aug 20 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 11.3-1
 - Typo fixes
 


### PR DESCRIPTION
The libglobus_rsl_assist library is an empty backwards compatibility library that is there to fulfil link dependencies from earlier versions of GT/GCT. The functionality that used to be provided by this library now is in libglobus_rsl. When linking the libglobus_rsl_assist library it links to libglobus_rsl (-lglobus_rsl), so that loading the empty compatibility library will load the globus_rsl library. However, many Linux distribution by default uses -Wl,--as-needed when linking during package builds (rpm/dpkg). This means that the link from libglobus_rsl_assist to libglobus_rsl is lost. This commit adds a dummy function that references a symbol in the libglobus_rsl library so that the link information is not removed when linking using -Wl,--as-needed.

In addition this commit declares the symbol "lvl" in libglobus_rsl static. This symbol is not in the globus_* namespace and has a very generic name and should therefore not by globally accessible.