### PR TITLE
Ignore unhandled PEM sequences

### DIFF
--- a/gsi/credential/source/library/globus_gsi_credential.c
+++ b/gsi/credential/source/library/globus_gsi_credential.c
@@ -1025,14 +1025,6 @@ globus_gsi_cred_read_proxy_bio(
                 goto exit;
             }
         }
-        else
-        {
-            GLOBUS_GSI_CRED_OPENSSL_ERROR_RESULT(
-                result,
-                GLOBUS_GSI_CRED_ERROR_READING_PROXY_CRED,
-                (_GCRSL("Unhandled PEM sequence: %s"), name));
-            goto exit;
-        }
         if (save_data)
         {
             OPENSSL_free(save_data);


### PR DESCRIPTION
I have a PEM file which contains a section denoted by a custom section. All other software I've tried happily ignores this section however GCT fails with:

```
Unable to read credential for import
globus_gsi_gssapi: Error with GSI credential
globus_credential: Error reading proxy credential: Unhandled PEM sequence: ...
```

[RFC 7468, Section 2](https://www.rfc-editor.org/rfc/rfc7468#section-2) doesn't explicitly state that parsers should ignore custom labels in PEM files, it does imply a level of flexibility in handling unrecognized or non-standard data, suggesting that well-designed parsers may indeed ignore custom labels and proceed with processing the rest of the file.

What do you think of removing this check so that unknown labels are ignored?