### PR TITLE
64 bit time_t

### DIFF
--- a/gass/transfer/source/configure.ac
+++ b/gass/transfer/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gass_transfer],[9.4],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gass_transfer],[9.5],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])
@@ -25,6 +25,6 @@ AC_CONFIG_FILES(
         globus-gass-transfer.pc
         Makefile
         library/Doxyfile
-	library/Makefile
-	version.h)
+        library/Makefile
+        version.h)
 AC_OUTPUT

--- a/gass/transfer/source/library/globus_gass_transfer_http.c
+++ b/gass/transfer/source/library/globus_gass_transfer_http.c
@@ -314,8 +314,8 @@ globus_l_gass_transfer_http_send(
 
 	/* send chunk header and footer as an iovec array */
 	sprintf((char *) new_proto->iov[0].iov_base,
-		"%lx%s",
-		(long) new_proto->user_buflen,
+		"%zx%s",
+		new_proto->user_buflen,
 		CRLF);
 	new_proto->iov[0].iov_len = strlen((char *) new_proto->iov[0].iov_base);
 
@@ -1728,7 +1728,7 @@ globus_l_gass_transfer_http_request_refer(
 		      GLOBUS_L_HTML_HEADER);
     offset += sprintf(referral_string + offset,
 		      GLOBUS_L_CONTENT_LENGTH_HEADER,
-		      (long) body_count);
+		      body_count);
     offset += sprintf(referral_string + offset,
 		      CRLF);
 
@@ -1838,7 +1838,7 @@ globus_l_gass_transfer_http_request_deny(
 		      GLOBUS_L_HTML_HEADER);
     offset += sprintf(deny_string + offset,
 		      GLOBUS_L_CONTENT_LENGTH_HEADER,
-		      (long) body_count);
+		      body_count);
     offset += sprintf(deny_string + offset,
 		      CRLF);
 
@@ -1941,7 +1941,7 @@ globus_l_gass_transfer_http_request_authorize(
 	{
 	    offset += sprintf(authorize_string + offset,
 			      GLOBUS_L_CONTENT_LENGTH_HEADER,
-			      (long) length);
+			      length);
 	}
 	offset += sprintf(authorize_string + offset,
 			  CRLF);

--- a/gass/transfer/source/library/globus_l_gass_transfer_http.h
+++ b/gass/transfer/source/library/globus_l_gass_transfer_http.h
@@ -128,7 +128,7 @@ static char * globus_l_gass_transfer_http_subject_name;
 
 #define GLOBUS_L_DEFAULT_DENIAL_MESSAGE	"Internal Server Error"
 
-#define GLOBUS_L_CONTENT_LENGTH_HEADER	"Content-Length: %ld" CRLF
+#define GLOBUS_L_CONTENT_LENGTH_HEADER	"Content-Length: %zu" CRLF
 #define GLOBUS_L_CHUNKED_HEADER		"Transfer-Encoding: chunked" CRLF
 #define GLOBUS_L_BINARY_HEADER		"Content-Type: " \
 					    "application/octet-stream" CRLF

--- a/gram/jobmanager/lrms/fork/source/configure.ac
+++ b/gram/jobmanager/lrms/fork/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gram_job_manager_fork],[3.3],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gram_job_manager_fork],[3.4],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])
@@ -38,11 +38,11 @@ AC_ARG_WITH(softenv-dir,
 AC_SUBST(SOFTENV_DIR)
 
 AC_ARG_WITH(globus-state-dir,
-	AC_HELP_STRING(
-		[--with-globus-state-dir=PATH],
-		[Path to Globus state files]),
-	globusstatedir="$withval",
-	globusstatedir=$localstatedir)
+    AC_HELP_STRING(
+        [--with-globus-state-dir=PATH],
+        [Path to Globus state files]),
+    globusstatedir="$withval",
+    globusstatedir=$localstatedir)
 
 # GRAM-333: SEG config in installer has variables that aren't resolved at
 # runtime
@@ -50,21 +50,21 @@ globusstatedir="`eval echo $globusstatedir`"
 AC_SUBST(globusstatedir)
 
 AC_ARG_WITH(seg,
-	AC_HELP_STRING(
-		[--with-seg=yes|no],
-		[Enable GRAM configuration with the SEG module]),
-	SEG_ENABLED="$withval",
-	SEG_ENABLED="no")
+    AC_HELP_STRING(
+        [--with-seg=yes|no],
+        [Enable GRAM configuration with the SEG module]),
+    SEG_ENABLED="$withval",
+    SEG_ENABLED="no")
 case "$SEG_ENABLED" in
-	yes)
-	    SEG_CLAUSE="-seg-module fork"
-	    ;;
-	no)
-	    SEG_CLAUSE=""
-	    ;;
-	*)
-	    AC_MSG_ERROR([Invalid argument to --with-seg])
-	    ;;
+    yes)
+        SEG_CLAUSE="-seg-module fork"
+        ;;
+    no)
+        SEG_CLAUSE=""
+        ;;
+    *)
+        AC_MSG_ERROR([Invalid argument to --with-seg])
+        ;;
 esac
 
 AC_SUBST(SEG_CLAUSE)
@@ -89,9 +89,9 @@ AC_SUBST(perlmoduledir)
 AC_CONFIG_FILES(
         globus-gram-job-manager-fork-uninstalled.pc
         globus-gram-job-manager-fork.pc
-	Makefile
-	globus-fork.conf
-	starter/Makefile
-	seg/Makefile
-	version.h)
+        Makefile
+        globus-fork.conf
+        starter/Makefile
+        seg/Makefile
+        version.h)
 AC_OUTPUT

--- a/gram/jobmanager/lrms/fork/source/seg/seg_fork_module.c
+++ b/gram/jobmanager/lrms/fork/source/seg/seg_fork_module.c
@@ -688,6 +688,7 @@ globus_l_fork_parse_events(
     char *                              p;
     int                                 protocol_msg_type;
     time_t                              stamp;
+    long long                           tmp_stamp;
     char *                              jobid;
     int                                 job_state;
     int                                 exit_code;
@@ -711,9 +712,9 @@ globus_l_fork_parse_events(
 
         exit_code = EXIT_CODE_UNASSIGNED;
 
-        rc = sscanf(p, "%d;%ld;%n%*[^;]%n;%d;%d", 
+        rc = sscanf(p, "%d;%lld;%n%*[^;]%n;%d;%d",
             &protocol_msg_type,
-            &stamp,
+            &tmp_stamp,
             &jobid_start,
             &jobid_end,
             &job_state,
@@ -723,6 +724,8 @@ globus_l_fork_parse_events(
         {
             goto bad_line;
         }
+
+        stamp = (time_t) tmp_stamp;
 
         jobid = p + jobid_start;
         *(p + jobid_end) = '\0';

--- a/gram/jobmanager/lrms/fork/source/starter/fork_starter.c
+++ b/gram/jobmanager/lrms/fork/source/starter/fork_starter.c
@@ -1230,8 +1230,8 @@ globus_l_fork_log_state_change(
         return;
     }
     fprintf(logfile,
-            "001;%lu;%s:%lu;%d;%d\n",
-            (unsigned long) now,
+            "001;%lld;%s:%lu;%d;%d\n",
+            (long long) now,
             task->jobid_prefix,
             (unsigned long) pid,
             (int) job_state,

--- a/gram/jobmanager/lrms/lsf/source/configure.ac
+++ b/gram/jobmanager/lrms/lsf/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gram_job_manager_lsf],[3.0],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gram_job_manager_lsf],[3.1],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])
@@ -29,11 +29,11 @@ fi
 
 AC_ARG_WITH([lsf-profile],
     AC_HELP_STRING(
-	[--with-lsf-profile=FILE],
+        [--with-lsf-profile=FILE],
         [Use LSF profile located at PATH ${LSF_ENVDIR:-/etc}/profile.lsf]),
-        [LSF_PROFILE=$withval],
-	[LSF_PROFILE="${LSF_ENVDIR:-/etc}/profile.lsf"
-         AC_MSG_WARN([Using default lsf profile of $LSF_PROFILE])])
+    [LSF_PROFILE=$withval],
+    [LSF_PROFILE="${LSF_ENVDIR:-/etc}/profile.lsf"
+        AC_MSG_WARN([Using default lsf profile of $LSF_PROFILE])])
 
 AC_SUBST(LSF_PROFILE)
 
@@ -88,11 +88,11 @@ AC_ARG_WITH(log-path,
 AC_SUBST(LSF_LOG_PATH)
 
 AC_ARG_WITH(globus-state-dir,
-	AC_HELP_STRING(
-		[--with-globus-state-dir=PATH],
-		[Path to Globus state files]),
-	globusstatedir="$withval",
-	globusstatedir=$localstatedir)
+    AC_HELP_STRING(
+        [--with-globus-state-dir=PATH],
+        [Path to Globus state files]),
+    globusstatedir="$withval",
+    globusstatedir=$localstatedir)
 
 # GRAM-333: SEG config in installer has variables that aren't resolved at
 # runtime
@@ -100,18 +100,18 @@ globusstatedir="`eval echo $globusstatedir`"
 AC_SUBST(globusstatedir)
 
 AC_ARG_WITH(seg,
-	AC_HELP_STRING(
-		[--with-seg=yes|no],
-		[Enable GRAM configuration with the SEG module]),
-	SEG_ENABLED="$withval",
-	SEG_ENABLED="no")
+    AC_HELP_STRING(
+        [--with-seg=yes|no],
+        [Enable GRAM configuration with the SEG module]),
+    SEG_ENABLED="$withval",
+    SEG_ENABLED="no")
 case "$SEG_ENABLED" in
-	yes|no)
+    yes|no)
             :
             ;;
-	*)
-	    AC_MSG_ERROR([Invalid argument to --with-seg])
-	    ;;
+    *)
+        AC_MSG_ERROR([Invalid argument to --with-seg])
+        ;;
 esac
 
 AC_ARG_WITH([perlmoduledir],
@@ -137,5 +137,5 @@ AC_CONFIG_FILES(
         globus-lsf.conf
         Makefile
         seg/Makefile
-	version.h)
+        version.h)
 AC_OUTPUT

--- a/gram/jobmanager/lrms/lsf/source/seg/seg_lsf_module.c
+++ b/gram/jobmanager/lrms/lsf/source/seg/seg_lsf_module.c
@@ -628,6 +628,7 @@ globus_l_lsf_find_logfile(
     const char                          lsf_idx_name[] = "lsb.events.1";
     int                                 i;
     time_t                              most_recent_event;
+    long long                           tmp_most_recent_event;
     GlobusFuncName(globus_l_lsf_find_logfile);
 
     SEGLsfEnter();
@@ -683,7 +684,8 @@ globus_l_lsf_find_logfile(
             }
             else
             {
-                fscanf(state->fp, "#%ld", &most_recent_event);
+                fscanf(state->fp, "#%lld", &tmp_most_recent_event);
+                most_recent_event = tmp_most_recent_event;
                 fclose(state->fp);
                 state->fp = NULL;
             }
@@ -805,6 +807,7 @@ globus_l_lsf_parse_events(
 {
     char *                              eol;
     time_t                              event_timestamp;
+    long long                           tmp_timestamp;
     char                                event_type_buffer[64];
     char                                job_id_buffer[32];
     int                                 rc;
@@ -848,15 +851,17 @@ globus_l_lsf_parse_events(
                  * the parsing timestamp to match that when we hit EOF.
                  */
                 sscanf(state->buffer + state->buffer_point + 1,
-                    "%ld", &state->end_of_file_timestamp);
+                    "%lld", &tmp_timestamp);
+                state->end_of_file_timestamp = tmp_timestamp;
                 goto next_line;
             }
         }
         sscanf(state->buffer + state->buffer_point,
-                "\"%[^\"]\" \"%*[^\"]\" %ld %s",
+                "\"%[^\"]\" \"%*[^\"]\" %lld %s",
                 event_type_buffer,
-                &event_timestamp,
+                &tmp_timestamp,
                 job_id_buffer);
+        event_timestamp = tmp_timestamp;
 
         if (event_timestamp < state->start_timestamp)
         {
@@ -895,8 +900,8 @@ globus_l_lsf_parse_events(
                  */
 
                 SEGLsfDebug(SEG_LSF_DEBUG_TRACE,
-                        ("ignoring JOB_STATUS: job %s in PEND state (%ld)\n",
-                        job_id_buffer, event_timestamp));
+                        ("ignoring JOB_STATUS: job %s in PEND state (%lld)\n",
+                        job_id_buffer, (long long) event_timestamp));
                 break;
             case JOB_STAT_PSUSP:
                 /*
@@ -904,16 +909,16 @@ globus_l_lsf_parse_events(
                  * the LSF administrator, while pending.
                  */
                 SEGLsfDebug(SEG_LSF_DEBUG_TRACE,
-                        ("ignoring JOB_STATUS: job %s in PSUSP state (%ld)\n",
-                        job_id_buffer, event_timestamp));
+                        ("ignoring JOB_STATUS: job %s in PSUSP state (%lld)\n",
+                        job_id_buffer, (long long) event_timestamp));
                 break;
             case JOB_STAT_RUN:
                 /*
                  * the job is currently running.
                  */
                 SEGLsfDebug(SEG_LSF_DEBUG_TRACE,
-                        ("ignoring JOB_STATUS: job %s in RUN state (%ld)\n",
-                        job_id_buffer, event_timestamp));
+                        ("ignoring JOB_STATUS: job %s in RUN state (%lld)\n",
+                        job_id_buffer, (long long) event_timestamp));
                 break;
 
             case JOB_STAT_SSUSP:
@@ -928,8 +933,8 @@ globus_l_lsf_parse_events(
                  *   bqueues(1),
                  */
                 SEGLsfDebug(SEG_LSF_DEBUG_TRACE,
-                        ("ignoring JOB_STATUS: job %s in SSUSP state (%ld)\n",
-                        job_id_buffer, event_timestamp));
+                        ("ignoring JOB_STATUS: job %s in SSUSP state (%lld)\n",
+                        job_id_buffer, (long long) event_timestamp));
                 break;
             case JOB_STAT_USUSP:
                 /*
@@ -937,8 +942,8 @@ globus_l_lsf_parse_events(
                  * the  LSF administrator, while running.
                  */
                 SEGLsfDebug(SEG_LSF_DEBUG_TRACE,
-                        ("ignoring JOB_STATUS: job %s in SSUSP state (%ld)\n",
-                        job_id_buffer, event_timestamp));
+                        ("ignoring JOB_STATUS: job %s in SSUSP state (%lld)\n",
+                        job_id_buffer, (long long) event_timestamp));
                 break;
             case JOB_STAT_EXIT:
                 /*
@@ -1000,16 +1005,16 @@ globus_l_lsf_parse_events(
                  * Post job process done successfully
                  */
                 SEGLsfDebug(SEG_LSF_DEBUG_TRACE,
-                        ("ignoring JOB_STATUS: job %s in PDONE state (%ld)\n",
-                        job_id_buffer, event_timestamp));
+                        ("ignoring JOB_STATUS: job %s in PDONE state (%lld)\n",
+                        job_id_buffer, (long long) event_timestamp));
                 break;
             case JOB_STAT_PERR:
                 /*
                  * Post job process has error
                  */
                 SEGLsfDebug(SEG_LSF_DEBUG_TRACE,
-                        ("ignoring JOB_STATUS: job %s in PERR state (%ld)\n",
-                        job_id_buffer, event_timestamp));
+                        ("ignoring JOB_STATUS: job %s in PERR state (%lld)\n",
+                        job_id_buffer, (long long) event_timestamp));
                 break;
             case JOB_STAT_WAIT:
                 /*
@@ -1017,19 +1022,19 @@ globus_l_lsf_parse_events(
                  * chunk job that are waiting to run.
                  */
                 SEGLsfDebug(SEG_LSF_DEBUG_TRACE,
-                        ("ignoring JOB_STATUS: job %s in WAIT state (%ld)\n",
-                        job_id_buffer, event_timestamp));
+                        ("ignoring JOB_STATUS: job %s in WAIT state (%lld)\n",
+                        job_id_buffer, (long long) event_timestamp));
                 break;
             case JOB_STAT_UNKWN:
                 SEGLsfDebug(SEG_LSF_DEBUG_TRACE,
                         ("ignoring JOB_STATUS: job %s in UNKNWN state "
-                                "(%ld)\n",
-                        job_id_buffer, event_timestamp));
+                                "(%lld)\n",
+                        job_id_buffer, (long long) event_timestamp));
                 break;
             case JOB_STAT_NULL:
                 SEGLsfDebug(SEG_LSF_DEBUG_TRACE,
-                        ("ignoring JOB_STATUS: job %s in NULL state (%ld)\n",
-                        job_id_buffer, event_timestamp));
+                        ("ignoring JOB_STATUS: job %s in NULL state (%lld)\n",
+                        job_id_buffer, (long long) event_timestamp));
                 break;
             }
         }

--- a/gram/jobmanager/scheduler_event_generator/source/configure.ac
+++ b/gram/jobmanager/scheduler_event_generator/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_scheduler_event_generator],[6.5],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_scheduler_event_generator],[6.6],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])
@@ -134,7 +134,7 @@ AC_CONFIG_FILES(
         init/globus-scheduler-event-generator-lsb
         init/Makefile
         test/Makefile
-	version.h)
+        version.h)
 AC_CONFIG_FILES([globus-scheduler-event-generator-admin],
     [chmod a+x globus-scheduler-event-generator-admin])
 AC_OUTPUT

--- a/gram/jobmanager/scheduler_event_generator/source/globus_scheduler_event_generator_stdout.c
+++ b/gram/jobmanager/scheduler_event_generator/source/globus_scheduler_event_generator_stdout.c
@@ -102,32 +102,32 @@ globus_scheduler_event_generator_stdout_handler(
     {
     case GLOBUS_SCHEDULER_EVENT_PENDING:
         return globus_l_stdout_scheduler_event(
-                "001;%lu;%s;%d;%d\n",
-                event->timestamp,
+                "001;%lld;%s;%d;%d\n",
+                (long long) event->timestamp,
                 event->job_id,
                 GLOBUS_GRAM_PROTOCOL_JOB_STATE_PENDING,
                 0);
 
     case GLOBUS_SCHEDULER_EVENT_ACTIVE:
         return globus_l_stdout_scheduler_event(
-                "001;%lu;%s;%d;%d\n",
-                event->timestamp,
+                "001;%lld;%s;%d;%d\n",
+                (long long) event->timestamp,
                 event->job_id,
                 GLOBUS_GRAM_PROTOCOL_JOB_STATE_ACTIVE,
                 0);
 
     case GLOBUS_SCHEDULER_EVENT_DONE:
         return globus_l_stdout_scheduler_event(
-                "001;%lu;%s;%d;%d\n",
-                event->timestamp,
+                "001;%lld;%s;%d;%d\n",
+                (long long) event->timestamp,
                 event->job_id,
                 GLOBUS_GRAM_PROTOCOL_JOB_STATE_DONE,
                 event->exit_code);
 
     case GLOBUS_SCHEDULER_EVENT_FAILED:
         return globus_l_stdout_scheduler_event(
-                "001;%lu;%s;%d;%d\n",
-                event->timestamp,
+                "001;%lld;%s;%d;%d\n",
+                (long long) event->timestamp,
                 event->job_id,
                 GLOBUS_GRAM_PROTOCOL_JOB_STATE_FAILED,
                 event->failure_code);
@@ -455,7 +455,7 @@ globus_l_xio_read_eof_callback(
 {
     globus_byte_t *                     tmp;
     ptrdiff_t                           offset;
-    unsigned long                       stamp;
+    long long                           stamp;
     globus_byte_t                      *next, *prev, *end;
 
     if (nbytes == len)
@@ -481,7 +481,7 @@ globus_l_xio_read_eof_callback(
     while (NULL != (next = (globus_byte_t *) strchr((char *) next, '\n')))
     {
         *next = '\0';
-        if (sscanf((char *) prev, "200 %lu", &stamp) == 1)
+        if (sscanf((char *) prev, "200 %lld", &stamp) == 1)
         {
             globus_scheduler_event_generator_set_timestamp((time_t) stamp);
         }

--- a/gram/jobmanager/scheduler_event_generator/source/main.c
+++ b/gram/jobmanager/scheduler_event_generator/source/main.c
@@ -61,6 +61,7 @@ main(int argc, char *argv[])
     int rc;
     char * module = NULL;
     time_t timestamp = 0;
+    long long tmp_timestamp;
     globus_result_t result = GLOBUS_SUCCESS;
     globus_bool_t background = GLOBUS_FALSE;
     char * directory = NULL;
@@ -109,13 +110,14 @@ main(int argc, char *argv[])
             break;
 
         case 't':
-            rc = sscanf(optarg, "%lu", (unsigned long*) &timestamp);
+            rc = sscanf(optarg, "%lld", &tmp_timestamp);
             if (rc < 1)
             {
                 fprintf(stderr, "Invalid timestamp [%s]\n", optarg);
                 goto deactivate_error;
 
             }
+            timestamp = (time_t) tmp_timestamp;
             break;
 
         case 'd':
@@ -427,32 +429,32 @@ globus_l_directory_write_event_handler(
     {
     case GLOBUS_SCHEDULER_EVENT_PENDING:
         fprintf(directory_write_fh,
-                "001;%lu;%s;%d;%d\n",
-                event->timestamp,
+                "001;%lld;%s;%d;%d\n",
+                (long long) event->timestamp,
                 event->job_id,
                 GLOBUS_GRAM_PROTOCOL_JOB_STATE_PENDING,
                 0);
         break;
     case GLOBUS_SCHEDULER_EVENT_ACTIVE:
         fprintf(directory_write_fh,
-                "001;%lu;%s;%d;%d\n",
-                event->timestamp,
+                "001;%lld;%s;%d;%d\n",
+                (long long) event->timestamp,
                 event->job_id,
                 GLOBUS_GRAM_PROTOCOL_JOB_STATE_ACTIVE,
                 0);
         break;
     case GLOBUS_SCHEDULER_EVENT_FAILED:
         fprintf(directory_write_fh,
-                "001;%lu;%s;%d;%d\n",
-                event->timestamp,
+                "001;%lld;%s;%d;%d\n",
+                (long long) event->timestamp,
                 event->job_id,
                 GLOBUS_GRAM_PROTOCOL_JOB_STATE_FAILED,
                 event->failure_code);
         break;
     case GLOBUS_SCHEDULER_EVENT_DONE:
         fprintf(directory_write_fh,
-                "001;%lu;%s;%d;%d\n",
-                event->timestamp,
+                "001;%lld;%s;%d;%d\n",
+                (long long) event->timestamp,
                 event->job_id,
                 GLOBUS_GRAM_PROTOCOL_JOB_STATE_DONE,
                 event->exit_code);

--- a/gram/jobmanager/scheduler_event_generator/source/test/globus_scheduler_event_generator_stdout.c
+++ b/gram/jobmanager/scheduler_event_generator/source/test/globus_scheduler_event_generator_stdout.c
@@ -96,32 +96,32 @@ globus_scheduler_event_generator_stdout_handler(
     {
     case GLOBUS_SCHEDULER_EVENT_PENDING:
         return globus_l_stdout_scheduler_event(
-                "001;%lu;%s;%d;%d\n",
-                event->timestamp,
+                "001;%lld;%s;%d;%d\n",
+                (long long) event->timestamp,
                 event->job_id,
                 GLOBUS_GRAM_PROTOCOL_JOB_STATE_PENDING,
                 0);
 
     case GLOBUS_SCHEDULER_EVENT_ACTIVE:
         return globus_l_stdout_scheduler_event(
-                "001;%lu;%s;%d;%d\n",
-                event->timestamp,
+                "001;%lld;%s;%d;%d\n",
+                (long long) event->timestamp,
                 event->job_id,
                 GLOBUS_GRAM_PROTOCOL_JOB_STATE_ACTIVE,
                 0);
 
     case GLOBUS_SCHEDULER_EVENT_DONE:
         return globus_l_stdout_scheduler_event(
-                "001;%lu;%s;%d;%d\n",
-                event->timestamp,
+                "001;%lld;%s;%d;%d\n",
+                (long long) event->timestamp,
                 event->job_id,
                 GLOBUS_GRAM_PROTOCOL_JOB_STATE_DONE,
                 event->exit_code);
 
     case GLOBUS_SCHEDULER_EVENT_FAILED:
         return globus_l_stdout_scheduler_event(
-                "001;%lu;%s;%d;%d\n",
-                event->timestamp,
+                "001;%lld;%s;%d;%d\n",
+                (long long) event->timestamp,
                 event->job_id,
                 GLOBUS_GRAM_PROTOCOL_JOB_STATE_DONE,
                 event->failure_code);

--- a/gram/jobmanager/scheduler_event_generator/source/test/seg_api_test.c
+++ b/gram/jobmanager/scheduler_event_generator/source/test/seg_api_test.c
@@ -43,7 +43,6 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    
     rc = globus_module_activate(GLOBUS_SCHEDULER_EVENT_GENERATOR_MODULE);
 
     if (rc != GLOBUS_SUCCESS)
@@ -76,13 +75,14 @@ int main(int argc, char *argv[])
     {
         int protocol_msg_type;
         time_t stamp;
+        long long tmp_stamp;
         char jobid[80];
         int state;
         int exit_code;
 
-        rc = sscanf(line, "%d;%ld;%[^;];%d;%d\n", 
+        rc = sscanf(line, "%d;%lld;%[^;];%d;%d\n",
             &protocol_msg_type,
-            &stamp,
+            &tmp_stamp,
             jobid,
             &state,
             &exit_code);
@@ -90,6 +90,7 @@ int main(int argc, char *argv[])
         {
             goto close_error;
         }
+        stamp = (time_t) tmp_stamp;
 
         if (protocol_msg_type != 1)
         {

--- a/gram/jobmanager/source/configure.ac
+++ b/gram/jobmanager/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gram_job_manager],[15.8],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gram_job_manager],[15.9],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])
@@ -135,10 +135,10 @@ AC_PATH_PROGS([A2X], [a2x a2x.py])
 AM_CONDITIONAL(BUILD_MANPAGES, [test x"$A2X" != x])
 
 AC_CONFIG_FILES([
-	globus-gram-job-manager-uninstalled.pc
-	globus-gram-job-manager.pc
-	scripts/Makefile
-	rvf/globus-rvf-edit
+        globus-gram-job-manager-uninstalled.pc
+        globus-gram-job-manager.pc
+        scripts/Makefile
+        rvf/globus-rvf-edit
         rvf/Makefile
         seg/Makefile
         test/Makefile

--- a/gram/jobmanager/source/globus_gram_job_manager_state_file.c
+++ b/gram/jobmanager/source/globus_gram_job_manager_state_file.c
@@ -199,18 +199,17 @@ globus_gram_job_manager_state_file_write(
     {
         goto error_exit;
     }
-    rc = fprintf(fp, "%lu\n",
-                 (unsigned long) request->seg_last_timestamp);
+    rc = fprintf(fp, "%lld\n", (long long) request->seg_last_timestamp);
     if (rc < 0)
     {
         goto error_exit;
     }
-    rc = fprintf(fp, "%lu\n", (unsigned long) request->creation_time);
+    rc = fprintf(fp, "%lld\n", (long long) request->creation_time);
     if (rc < 0)
     {
         goto error_exit;
     }
-    rc = fprintf(fp, "%lu\n", (unsigned long) request->queued_time);
+    rc = fprintf(fp, "%lld\n", (long long) request->queued_time);
     if (rc < 0)
     {
         goto error_exit;
@@ -237,22 +236,22 @@ globus_gram_job_manager_state_file_write(
         goto error_exit;
     }
     rc = fprintf(fp,
-            "%ld.%09ld %ld.%09ld %ld.%09ld "
-            "%ld.%09ld %ld.%09ld %ld.%09ld %ld.%09ld "
+            "%lld.%09ld %lld.%09ld %lld.%09ld "
+            "%lld.%09ld %lld.%09ld %lld.%09ld %lld.%09ld "
             "%d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
-            request->job_stats.unsubmitted_timestamp.tv_sec,
+            (long long) request->job_stats.unsubmitted_timestamp.tv_sec,
             request->job_stats.unsubmitted_timestamp.tv_nsec,
-            request->job_stats.file_stage_in_timestamp.tv_sec,
+            (long long) request->job_stats.file_stage_in_timestamp.tv_sec,
             request->job_stats.file_stage_in_timestamp.tv_nsec,
-            request->job_stats.pending_timestamp.tv_sec,
+            (long long) request->job_stats.pending_timestamp.tv_sec,
             request->job_stats.pending_timestamp.tv_nsec,
-            request->job_stats.active_timestamp.tv_sec,
+            (long long) request->job_stats.active_timestamp.tv_sec,
             request->job_stats.active_timestamp.tv_nsec,
-            request->job_stats.failed_timestamp.tv_sec,
+            (long long) request->job_stats.failed_timestamp.tv_sec,
             request->job_stats.failed_timestamp.tv_nsec,
-            request->job_stats.file_stage_out_timestamp.tv_sec,
+            (long long) request->job_stats.file_stage_out_timestamp.tv_sec,
             request->job_stats.file_stage_out_timestamp.tv_nsec,
-            request->job_stats.done_timestamp.tv_sec,
+            (long long) request->job_stats.done_timestamp.tv_sec,
             request->job_stats.done_timestamp.tv_nsec,
             request->job_stats.restart_count,
             request->job_stats.callback_count,
@@ -406,7 +405,15 @@ globus_gram_job_manager_state_file_read(
     struct stat                         statbuf;
     int                                 rc = GLOBUS_SUCCESS;
     int                                 i;
-    unsigned long                       tmp_timestamp;
+    long long                           tmp_timestamp;
+
+    long long                           tmp_unsubmitted_timestamp;
+    long long                           tmp_file_stage_in_timestamp;
+    long long                           tmp_pending_timestamp;
+    long long                           tmp_active_timestamp;
+    long long                           tmp_failed_timestamp;
+    long long                           tmp_file_stage_out_timestamp;
+    long long                           tmp_done_timestamp;
 
     request->old_job_contact = NULL;
 
@@ -615,7 +622,7 @@ globus_gram_job_manager_state_file_read(
         goto free_scratchdir;
     }
     buffer[strlen(buffer)-1] = '\0';
-    sscanf(buffer, "%lu", &tmp_timestamp);
+    sscanf(buffer, "%lld", &tmp_timestamp);
     request->seg_last_timestamp = (time_t) tmp_timestamp;
 
     if (fgets( buffer, file_len, fp ) == NULL)
@@ -623,14 +630,14 @@ globus_gram_job_manager_state_file_read(
         goto free_scratchdir;
     }
     buffer[strlen(buffer)-1] = '\0';
-    sscanf(buffer, "%lu", &tmp_timestamp);
+    sscanf(buffer, "%lld", &tmp_timestamp);
     request->creation_time = (time_t) tmp_timestamp;
     if (fgets( buffer, file_len, fp ) == NULL)
     {
         goto free_scratchdir;
     }
     buffer[strlen(buffer)-1] = '\0';
-    sscanf(buffer, "%lu", &tmp_timestamp);
+    sscanf(buffer, "%lld", &tmp_timestamp);
     request->queued_time = (time_t) tmp_timestamp;
 
     request->stage_in_todo = NULL;
@@ -674,23 +681,24 @@ globus_gram_job_manager_state_file_read(
         goto free_gateway_user;
     }
     buffer[strlen(buffer)-1] = 0;
+
     sscanf(buffer,
-            "%ld.%09ld %ld.%09ld %ld.%09ld "
-            "%ld.%09ld %ld.%09ld %ld.%09ld %ld.%09ld "
+            "%lld.%09ld %lld.%09ld %lld.%09ld "
+            "%lld.%09ld %lld.%09ld %lld.%09ld %lld.%09ld "
             "%d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d",
-            &request->job_stats.unsubmitted_timestamp.tv_sec,
+            &tmp_unsubmitted_timestamp,
             &request->job_stats.unsubmitted_timestamp.tv_nsec,
-            &request->job_stats.file_stage_in_timestamp.tv_sec,
+            &tmp_file_stage_in_timestamp,
             &request->job_stats.file_stage_in_timestamp.tv_nsec,
-            &request->job_stats.pending_timestamp.tv_sec,
+            &tmp_pending_timestamp,
             &request->job_stats.pending_timestamp.tv_nsec,
-            &request->job_stats.active_timestamp.tv_sec,
+            &tmp_active_timestamp,
             &request->job_stats.active_timestamp.tv_nsec,
-            &request->job_stats.failed_timestamp.tv_sec,
+            &tmp_failed_timestamp,
             &request->job_stats.failed_timestamp.tv_nsec,
-            &request->job_stats.file_stage_out_timestamp.tv_sec,
+            &tmp_file_stage_out_timestamp,
             &request->job_stats.file_stage_out_timestamp.tv_nsec,
-            &request->job_stats.done_timestamp.tv_sec,
+            &tmp_done_timestamp,
             &request->job_stats.done_timestamp.tv_nsec,
             &request->job_stats.restart_count,
             &request->job_stats.callback_count,
@@ -712,6 +720,18 @@ globus_gram_job_manager_state_file_read(
             &request->job_stats.file_stage_out_https_count,
             &request->job_stats.file_stage_out_ftp_count,
             &request->job_stats.file_stage_out_gsiftp_count);
+
+    request->job_stats.unsubmitted_timestamp.tv_sec =
+      tmp_unsubmitted_timestamp;
+    request->job_stats.file_stage_in_timestamp.tv_sec =
+      tmp_file_stage_in_timestamp;
+    request->job_stats.pending_timestamp.tv_sec = tmp_pending_timestamp;
+    request->job_stats.active_timestamp.tv_sec = tmp_active_timestamp;
+    request->job_stats.failed_timestamp.tv_sec = tmp_failed_timestamp;
+    request->job_stats.file_stage_out_timestamp.tv_sec =
+      tmp_file_stage_out_timestamp;
+    request->job_stats.done_timestamp.tv_sec = tmp_done_timestamp;
+
     if (fgets( buffer, file_len, fp ) == NULL)
     {
         goto free_gateway_user;

--- a/gram/jobmanager/source/seg/seg_job_manager_module.c
+++ b/gram/jobmanager/source/seg/seg_job_manager_module.c
@@ -719,6 +719,7 @@ globus_l_job_manager_parse_events(
     int                                 rc;
     int                                 protocol_msg_type;
     time_t                              stamp;
+    long long                           tmp_stamp;
     char                                jobid[129];
     char                                nl[2];
     int                                 job_state;
@@ -731,14 +732,15 @@ globus_l_job_manager_parse_events(
 
 
     fgetpos(state->fp, &pos);
-    while ((rc = fscanf(state->fp, "%d;%ld;%128[^;];%d;%d%1[\n]",
+    while ((rc = fscanf(state->fp, "%d;%lld;%128[^;];%d;%d%1[\n]",
                     &protocol_msg_type,
-                    &stamp,
+                    &tmp_stamp,
                     jobid,
                     &job_state,
                     &exit_code,
                     nl)) > 4)
     {
+        stamp = tmp_stamp;
         if (rc == 4 && fscanf(state->fp, "%1[\n]", nl) != 1)
         {
             goto bad_line;

--- a/gram/jobmanager/source/test/client/status-test.c
+++ b/gram/jobmanager/source/test/client/status-test.c
@@ -150,9 +150,9 @@ destroy_callback_contact:
         GlobusTimeAbstimeDiff(delta, start_time, stop_time);
 
         fprintf(stderr,
-                "Made %d calls to status in %ld.%06ld seconds\n",
+                "Made %d calls to status in %lld.%06ld seconds\n",
                 calls,
-                (long) delta.tv_sec,
+                (long long) delta.tv_sec,
                 (long) delta.tv_usec);
     }
     globus_mutex_unlock(&monitor.mutex);

--- a/gridftp/client/source/configure.ac
+++ b/gridftp/client/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_ftp_client],[9.8],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_ftp_client],[9.9],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])
@@ -112,6 +112,6 @@ AC_CONFIG_FILES(
         Makefile
         Doxyfile
         test/Makefile
-	version.h
+        version.h
         test/testcred.cnf)
 AC_OUTPUT

--- a/gridftp/client/source/globus_ftp_client_perf_plugin.c
+++ b/gridftp/client/source/globus_ftp_client_perf_plugin.c
@@ -177,7 +177,7 @@ perf_plugin_response_cb(
     char *                                      buffer;
     char *                                      tmp_ptr;
     int                                         count;
-    long                                        time_stamp_int;
+    time_t                                      time_stamp_int;
     char                                        time_stamp_tenth;
     int                                         stripe_ndx;
     int                                         num_stripes;
@@ -301,7 +301,7 @@ perf_plugin_data_cb(
 {
     perf_plugin_info_t *                        ps;
     globus_abstime_t                            timebuf;
-    long                                        secs;
+    time_t                                      secs;
     long                                        usecs;
     double                                      time_now;
 

--- a/gridftp/client/source/globus_ftp_client_perf_plugin.h
+++ b/gridftp/client/source/globus_ftp_client_perf_plugin.h
@@ -133,7 +133,7 @@ typedef void (*globus_ftp_client_perf_plugin_begin_cb_t)(
 typedef void (*globus_ftp_client_perf_plugin_marker_cb_t)(
     void *                                          user_specific,
     globus_ftp_client_handle_t *                    handle,
-    long                                            time_stamp_int,
+    time_t                                          time_stamp_int,
     char                                            time_stamp_tenth,
     int                                             stripe_ndx,
     int                                             num_stripes,

--- a/gridftp/client/source/globus_ftp_client_throughput_plugin.c
+++ b/gridftp/client/source/globus_ftp_client_throughput_plugin.c
@@ -103,7 +103,7 @@ throughput_plugin_begin_cb(
 {
     throughput_plugin_info_t *                  info;
     globus_abstime_t                            timebuf;
-    long                                        secs;
+    time_t                                      secs;
     long                                        usecs;
     globus_ftp_client_restart_marker_t          marker;
     globus_off_t                                total_bytes;
@@ -157,7 +157,7 @@ void
 throughput_plugin_marker_cb(
     void *                                      user_specific,
     globus_ftp_client_handle_t *                handle,
-    long                                        time_stamp_int,
+    time_t                                      time_stamp_int,
     char                                        time_stamp_tenth,
     int                                         stripe_ndx,
     int                                         num_stripes,

--- a/gridftp/client/source/test/globus_ftp_client_test_common.c
+++ b/gridftp/client/source/test/globus_ftp_client_test_common.c
@@ -55,8 +55,8 @@ test_parse_args(int argc,
     globus_abstime_t deadline_time;
     globus_reltime_t interval_time;
     int max_retries;
-    long interval;
-    long deadline;
+    long long interval;
+    long long deadline;
     char * subject;
 
     *src = GLOBUS_NULL;
@@ -213,7 +213,7 @@ test_parse_args(int argc,
 	    break;
 	case 'f':
 	    globus_module_activate(GLOBUS_FTP_CLIENT_RESTART_PLUGIN_MODULE);
-	    sscanf(optarg, "%d,%ld,%ld", &max_retries, &interval, &deadline);
+	    sscanf(optarg, "%d,%lld,%lld", &max_retries, &interval, &deadline);
 
 	    if(interval < 0.1)
 	    {

--- a/gridftp/client/source/test/globus_ftp_client_test_perf_plugin.c
+++ b/gridftp/client/source/test/globus_ftp_client_test_perf_plugin.c
@@ -60,14 +60,14 @@ static
 void perf_plugin_marker_cb(
     void *                                          user_specific,
     globus_ftp_client_handle_t *                    handle,
-    long                                            time_stamp_int,
+    time_t                                          time_stamp_int,
     char                                            time_stamp_tenth,
     int                                             stripe_ndx,
     int                                             num_stripes,
     globus_off_t                                    nbytes)
 {
     globus_libc_fprintf(stderr, "perf_plugin_marker_cb\n");
-    globus_libc_fprintf(stderr, "time_stamp   %ld.%d\n", time_stamp_int, time_stamp_tenth);
+    globus_libc_fprintf(stderr, "time_stamp   %lld.%hhd\n", (long long) time_stamp_int, time_stamp_tenth);
     globus_libc_fprintf(stderr, "stripe_ndx   %d\n", stripe_ndx);
     globus_libc_fprintf(stderr, "num_stripes  %d\n", num_stripes);
     globus_libc_fprintf(stderr, "nbytes       %" GLOBUS_OFF_T_FORMAT "\n", nbytes);

--- a/gridftp/client/source/test/partial-read-all-test.c
+++ b/gridftp/client/source/test/partial-read-all-test.c
@@ -60,7 +60,7 @@ intermediate_cb(
     globus_off_t				offset,
     globus_bool_t				eof)
 {
-    printf("intermediate cb: [%"GLOBUS_OFF_T_FORMAT",%ld]\n", offset, length);
+    printf("intermediate cb: [%"GLOBUS_OFF_T_FORMAT",%zu]\n", offset, length);
     fwrite(buffer, 1, length, stdout);
 }
 static
@@ -74,7 +74,7 @@ data_cb(
     globus_off_t				offset,
     globus_bool_t				eof)
 {
-    printf("[%"GLOBUS_OFF_T_FORMAT",%ld]\n", offset, length);
+    printf("[%"GLOBUS_OFF_T_FORMAT",%zu]\n", offset, length);
     fwrite(buffer, 1, length - offset, stdout);
 }
 

--- a/gridftp/client/source/test/read-all-test.c
+++ b/gridftp/client/source/test/read-all-test.c
@@ -60,7 +60,7 @@ intermediate_cb(
     globus_off_t				offset,
     globus_bool_t				eof)
 {
-    printf("intermediate cb: [%"GLOBUS_OFF_T_FORMAT",%ld]\n", offset, length);
+    printf("intermediate cb: [%"GLOBUS_OFF_T_FORMAT",%zu]\n", offset, length);
     fwrite(buffer, 1, length, stdout);
 }
 static
@@ -74,7 +74,7 @@ data_cb(
     globus_off_t				offset,
     globus_bool_t				eof)
 {
-    printf("[%"GLOBUS_OFF_T_FORMAT",%ld]\n", offset, length);
+    printf("[%"GLOBUS_OFF_T_FORMAT",%zu]\n", offset, length);
     fwrite(buffer, 1, length, stdout);
 }
 

--- a/gridftp/server-lib/src/configure.ac
+++ b/gridftp/server-lib/src/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gridftp_server_control],[9.3],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gridftp_server_control],[9.4],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])
@@ -21,6 +21,6 @@ AC_CONFIG_FILES(
         globus-gridftp-server-control.pc
         globus-gridftp-server-control-uninstalled.pc
         Makefile
-	version.h
+        version.h
         test/Makefile)
 AC_OUTPUT

--- a/gridftp/server-lib/src/globus_gridftp_server_control_events.c
+++ b/gridftp/server-lib/src/globus_gridftp_server_control_events.c
@@ -339,12 +339,12 @@ globus_l_gsc_send_perf(
     gettimeofday(&now, NULL);
     msg = globus_common_create_string(
         "112-Perf Marker\r\n"
-        " Timestamp:  %ld.%01ld\r\n"
+        " Timestamp: %lld.%01d\r\n"
         " Stripe Index: %d\r\n"
         " Stripe Bytes Transferred: %"GLOBUS_OFF_T_FORMAT"\r\n"
         " Total Stripe Count: %d\r\n"
         "112 End.\r\n",
-            now.tv_sec, now.tv_usec / 100000,
+            (long long) now.tv_sec, (int) (now.tv_usec / 100000),
             stripe_ndx,
             nbytes,
             stripe_count);

--- a/gridftp/server/src/configure.ac
+++ b/gridftp/server/src/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gridftp_server],[13.26],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gridftp_server],[13.27],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gridftp/server/src/globus_i_gfs_control.c
+++ b/gridftp/server/src/globus_i_gfs_control.c
@@ -1061,11 +1061,11 @@ globus_l_gfs_data_command_cb(
                 gettimeofday(&now, NULL);
                 msg = globus_common_create_string(
                     "%d-Status Marker\r\n"
-                    " Timestamp: %ld.%01ld\r\n"
+                    " Timestamp: %lld.%01d\r\n"
                     " Bytes Processed: %s\r\n"
                     "%d End.\r\n",
                     reply->code,
-                    now.tv_sec, now.tv_usec / 100000,
+                    (long long) now.tv_sec, (int) (now.tv_usec / 100000),
                     reply->info.command.checksum,
                     reply->code);
                 globus_i_gsc_cmd_intermediate_reply(op, msg);
@@ -1098,12 +1098,12 @@ globus_l_gfs_data_command_cb(
                   case 112:
                     msg = globus_common_create_string(
                         "112-Perf Marker\r\n"
-                        " Timestamp:  %ld.%01ld\r\n"
+                        " Timestamp: %lld.%01d\r\n"
                         " Stripe Index: 0\r\n"
                         " Stripe Bytes Transferred: %s\r\n"
                         " Total Stripe Count: 1\r\n"
                         "112 End.\r\n",
-                        now.tv_sec, now.tv_usec / 100000,
+                        (long long) now.tv_sec, (int) (now.tv_usec / 100000),
                         reply->info.command.checksum);
                         break;
                   default:

--- a/myproxy/source/configure.ac
+++ b/myproxy/source/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT([myproxy],[6.2.16])
+AC_INIT([myproxy],[6.2.17])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign])
 LT_INIT([dlopen win32-dll])

--- a/myproxy/source/myproxy.c
+++ b/myproxy/source/myproxy.c
@@ -1753,7 +1753,7 @@ myproxy_serialize_response_ex(const myproxy_response_t *response,
                 if (len == -1)
                     goto error;
             }
-            sprintf(date, "%lu",  cred->start_time);
+            sprintf(date, "%lld", (long long) cred->start_time);
             if (first_cred) {
                 len = my_append(data, MYPROXY_CRED_PREFIX,
                                 "_", MYPROXY_START_TIME_STRING,
@@ -1766,7 +1766,7 @@ myproxy_serialize_response_ex(const myproxy_response_t *response,
             }
             if (len == -1)
                 goto error;
-            sprintf(date, "%lu", cred->end_time);
+            sprintf(date, "%lld", (long long) cred->end_time);
             if (first_cred) {
                 len = my_append(data, MYPROXY_CRED_PREFIX,
                                 "_", MYPROXY_END_TIME_STRING,

--- a/myproxy/source/myproxy_creds.c
+++ b/myproxy/source/myproxy_creds.c
@@ -2000,7 +2000,7 @@ myproxy_install_trusted_cert_files(myproxy_certs_t *trusted_certs)
                               tmp_path, file_path);
             goto error;
         }
-        fprintf(log_file, "%ld: %s\n", time(NULL), file_path);
+        fprintf(log_file, "%lld: %s\n", (long long) time(NULL), file_path);
         free(file_path);
         file_path = NULL;
         free(tmp_path);

--- a/packaging/debian/globus-ftp-client/debian/changelog.in
+++ b/packaging/debian/globus-ftp-client/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-ftp-client (9.9-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix format warnings on 32 bit systems
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 01 Mar 2024 11:13:14 +0100
+
 globus-ftp-client (9.8-1+gct.@distro@) @distro@; urgency=medium
 
   * Fix some compiler and doxygen warnings

--- a/packaging/debian/globus-ftp-client/debian/changelog.in
+++ b/packaging/debian/globus-ftp-client/debian/changelog.in
@@ -1,6 +1,7 @@
 globus-ftp-client (9.9-1+gct.@distro@) @distro@; urgency=medium
 
   * Fix format warnings on 32 bit systems
+  * Handle 64 bit time_t on 32 bit systems
 
  -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 01 Mar 2024 11:13:14 +0100
 

--- a/packaging/debian/globus-gass-transfer/debian/changelog.in
+++ b/packaging/debian/globus-gass-transfer/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gass-transfer (9.5-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix format warnings on 32 bit systems
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 01 Mar 2024 11:09:20 +0100
+
 globus-gass-transfer (9.4-1+gct.@distro@) @distro@; urgency=medium
 
   * Fix some compiler and doxygen warnings

--- a/packaging/debian/globus-gram-job-manager-fork/debian/changelog.in
+++ b/packaging/debian/globus-gram-job-manager-fork/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gram-job-manager-fork (3.4-1+gct.@distro@) @distro@; urgency=medium
+
+  * Handle 64 bit time_t on 32 bit systems
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 01 Mar 2024 11:28:43 +0100
+
 globus-gram-job-manager-fork (3.3-1+gct.@distro@) @distro@; urgency=medium
 
   * Fix some compiler warnings

--- a/packaging/debian/globus-gram-job-manager-lsf/debian/changelog.in
+++ b/packaging/debian/globus-gram-job-manager-lsf/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gram-job-manager-lsf (3.1-1+gct.@distro@) @distro@; urgency=medium
+
+  * Handle 64 bit time_t on 32 bit systems
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Sun, 10 Mar 2024 20:41:04 +0100
+
 globus-gram-job-manager-lsf (3.0-1+gct.@distro@) @distro@; urgency=medium
 
   * First Grid Community Toolkit release

--- a/packaging/debian/globus-gram-job-manager/debian/changelog.in
+++ b/packaging/debian/globus-gram-job-manager/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gram-job-manager (15.9-1+gct.@distro@) @distro@; urgency=medium
+
+  * Handle 64 bit time_t on 32 bit systems
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 01 Mar 2024 11:34:58 +0100
+
 globus-gram-job-manager (15.8-1+gct.@distro@) @distro@; urgency=medium
 
   * Fix some compiler warnings

--- a/packaging/debian/globus-gridftp-server-control/debian/changelog.in
+++ b/packaging/debian/globus-gridftp-server-control/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gridftp-server-control (9.4-1+gct.@distro@) @distro@; urgency=medium
+
+  * Handle 64 bit time_t on 32 bit systems
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Sat, 16 Mar 2024 03:38:32 +0100
+
 globus-gridftp-server-control (9.3-1+gct.@distro@) @distro@; urgency=medium
 
   * Fix some compiler warnings

--- a/packaging/debian/globus-gridftp-server/debian/changelog.in
+++ b/packaging/debian/globus-gridftp-server/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gridftp-server (13.27-1+gct.@distro@) @distro@; urgency=medium
+
+  * Handle 64 bit time_t on 32 bit systems
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Sat, 16 Mar 2024 03:39:44 +0100
+
 globus-gridftp-server (13.26-1+gct.@distro@) @distro@; urgency=medium
 
   * Correct spelling error found by lintian

--- a/packaging/debian/globus-scheduler-event-generator/debian/changelog.in
+++ b/packaging/debian/globus-scheduler-event-generator/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-scheduler-event-generator (6.6-1+gct.@distro@) @distro@; urgency=medium
+
+  * Handle 64 bit time_t on 32 bit systems
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 01 Mar 2024 11:32:24 +0100
+
 globus-scheduler-event-generator (6.5-1+gct.@distro@) @distro@; urgency=medium
 
   * Fix some compiler warnings

--- a/packaging/debian/myproxy/debian/changelog.in
+++ b/packaging/debian/myproxy/debian/changelog.in
@@ -1,3 +1,9 @@
+myproxy (6.2.17-1+gct.@distro@) @distro@; urgency=medium
+
+  * Handle 64 bit time_t on 32 bit systems
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Sun, 17 Mar 2024 21:20:22 +0100
+
 myproxy (6.2.16-1+gct.@distro@) @distro@; urgency=medium
 
   * Fix compilation errors from stricter type checking

--- a/packaging/fedora/globus-ftp-client.spec
+++ b/packaging/fedora/globus-ftp-client.spec
@@ -3,7 +3,7 @@
 Name:		globus-ftp-client
 %global soname 2
 %global _name %(echo %{name} | tr - _)
-Version:	9.8
+Version:	9.9
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GridFTP Client Library
 
@@ -169,6 +169,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Fri Mar 01 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.9-1
+- Fix format warnings on 32 bit systems
+
 * Wed Mar 09 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.8-1
 - Fix some compiler and doxygen warnings
 

--- a/packaging/fedora/globus-ftp-client.spec
+++ b/packaging/fedora/globus-ftp-client.spec
@@ -171,6 +171,7 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %changelog
 * Fri Mar 01 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.9-1
 - Fix format warnings on 32 bit systems
+- Handle 64 bit time_t on 32 bit systems
 
 * Wed Mar 09 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.8-1
 - Fix some compiler and doxygen warnings

--- a/packaging/fedora/globus-gass-transfer.spec
+++ b/packaging/fedora/globus-gass-transfer.spec
@@ -3,7 +3,7 @@
 Name:		globus-gass-transfer
 %global soname 2
 %global _name %(echo %{name} | tr - _)
-Version:	9.4
+Version:	9.5
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus Gass Transfer
 
@@ -131,6 +131,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.la
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Fri Mar 01 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.5-1
+- Fix format warnings on 32 bit systems
+
 * Wed Mar 09 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.4-1
 - Fix some compiler and doxygen warnings
 

--- a/packaging/fedora/globus-gram-job-manager-fork.spec
+++ b/packaging/fedora/globus-gram-job-manager-fork.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gram-job-manager-fork
 %global _name %(echo %{name} | tr - _)
-Version:	3.3
+Version:	3.4
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Fork Job Manager Support
 
@@ -173,6 +173,9 @@ fi
 %config(noreplace) %{_sysconfdir}/globus/scheduler-event-generator/available/fork
 
 %changelog
+* Fri Mar 01 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 3.4-1
+- Handle 64 bit time_t on 32 bit systems
+
 * Fri Mar 11 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 3.3-1
 - Fix some compiler warnings
 

--- a/packaging/fedora/globus-gram-job-manager-lsf.spec
+++ b/packaging/fedora/globus-gram-job-manager-lsf.spec
@@ -2,8 +2,8 @@
 
 Name:		globus-gram-job-manager-lsf
 %global _name %(echo %{name} | tr - _)
-Version:	3.0
-Release:	2%{?dist}
+Version:	3.1
+Release:	1%{?dist}
 Summary:	Grid Community Toolkit - LSF Job Manager Support
 
 Group:		Applications/Internet
@@ -170,6 +170,9 @@ fi
 %config(noreplace) %{_sysconfdir}/globus/scheduler-event-generator/available/lsf
 
 %changelog
+* Sun Mar 10 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 3.1-1
+- Handle 64 bit time_t on 32 bit systems
+
 * Thu Mar 12 2020 Mattias Ellert <mattias.ellert@physics.uu.se> - 3.0-2
 - Add BuildRequires perl-interpreter
 

--- a/packaging/fedora/globus-gram-job-manager.spec
+++ b/packaging/fedora/globus-gram-job-manager.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gram-job-manager
 %global _name %(echo %{name} | tr - _)
-Version:	15.8
+Version:	15.9
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GRAM Jobmanager
 
@@ -169,6 +169,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %{_libdir}/libglobus_seg_job_manager.so
 
 %changelog
+* Fri Mar 01 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 15.9-1
+- Handle 64 bit time_t on 32 bit systems
+
 * Fri Mar 11 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 15.8-1
 - Fix some compiler warnings
 

--- a/packaging/fedora/globus-gridftp-server-control.spec
+++ b/packaging/fedora/globus-gridftp-server-control.spec
@@ -3,7 +3,7 @@
 Name:		globus-gridftp-server-control
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	9.3
+Version:	9.4
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GridFTP Server Library
 
@@ -112,6 +112,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.la
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Sat Mar 16 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.4-1
+- Handle 64 bit time_t on 32 bit systems
+
 * Thu Mar 10 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.3-1
 - Fix some compiler warnings
 

--- a/packaging/fedora/globus-gridftp-server.spec
+++ b/packaging/fedora/globus-gridftp-server.spec
@@ -3,7 +3,7 @@
 Name:		globus-gridftp-server
 %global soname 6
 %global _name %(echo %{name} | tr - _)
-Version:	13.26
+Version:	13.27
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GridFTP Server
 
@@ -223,6 +223,9 @@ fi
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Sat Mar 16 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 13.27-1
+- Handle 64 bit time_t on 32 bit systems
+
 * Fri Mar 08 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 13.26-1
 - Correct spelling error found by lintian
 

--- a/packaging/fedora/globus-scheduler-event-generator.spec
+++ b/packaging/fedora/globus-scheduler-event-generator.spec
@@ -3,7 +3,7 @@
 Name:		globus-scheduler-event-generator
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	6.5
+Version:	6.6
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Scheduler Event Generator
 
@@ -239,6 +239,9 @@ fi
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Fri Mar 01 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.6-1
+- Handle 64 bit time_t on 32 bit systems
+
 * Thu Mar 10 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.5-1
 - Fix some compiler warnings
 

--- a/packaging/fedora/myproxy.spec
+++ b/packaging/fedora/myproxy.spec
@@ -2,7 +2,7 @@
 
 Name:           myproxy
 %global soname 6
-Version:        6.2.16
+Version:        6.2.17
 Release:        1%{?dist}
 Summary:        Manage X.509 Public Key Infrastructure (PKI) security credentials
 
@@ -387,6 +387,9 @@ fi
 %doc %{_pkgdocdir}/LICENSE*
 
 %changelog
+* Sun Mar 17 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.17-1
+- Handle 64 bit time_t on 32 bit systems
+
 * Wed Jan 17 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.16-1
 - Fix compilation errors from stricter type checking
 


### PR DESCRIPTION
Debian recently migrated to using a 64 bit time_t on most of their 32 bit architectures.
This leads to issues where a time_t variable is used in printf or sscanf.
This PR addresses those issues (and a few cases with size_t vs. long that I found when checking logs on 32 bit).
