### PR TITLE
Passing argument from incompatible pointer type

### DIFF
--- a/gridftp/server-lib/src/configure.ac
+++ b/gridftp/server-lib/src/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gridftp_server_control],[9.4],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gridftp_server_control],[9.5],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gridftp/server-lib/src/test/globus_ftp_telnet_client.c
+++ b/gridftp/server-lib/src/test/globus_ftp_telnet_client.c
@@ -53,7 +53,7 @@ main(
     globus_bool_t                           done = GLOBUS_FALSE;
     globus_size_t                           nbytes;
     globus_xio_attr_t                       attr;
-    int                                     len;
+    globus_size_t                           len;
     globus_xio_iovec_t                      readv;
 
     if(argc < 2)

--- a/packaging/debian/globus-gridftp-server-control/debian/changelog.in
+++ b/packaging/debian/globus-gridftp-server-control/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gridftp-server-control (9.5-1+gct.@distro@) @distro@; urgency=medium
+
+  * Passing argument from incompatible pointer type
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Thu, 11 Jul 2024 13:19:25 +0200
+
 globus-gridftp-server-control (9.4-1+gct.@distro@) @distro@; urgency=medium
 
   * Handle 64 bit time_t on 32 bit systems

--- a/packaging/fedora/globus-gridftp-server-control.spec
+++ b/packaging/fedora/globus-gridftp-server-control.spec
@@ -3,7 +3,7 @@
 Name:		globus-gridftp-server-control
 %global soname 0
 %global _name %(echo %{name} | tr - _)
-Version:	9.4
+Version:	9.5
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GridFTP Server Library
 
@@ -112,6 +112,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.la
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Thu Jul 11 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.5-1
+- Passing argument from incompatible pointer type
+
 * Sat Mar 16 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 9.4-1
 - Handle 64 bit time_t on 32 bit systems
 


### PR DESCRIPTION
Reported to Debian Bug Tracking System (BTS):
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1075012
```
globus_ftp_telnet_client.c:100:58: error: passing argument 5 of ‘globus_xio_readv’ from incompatible pointer type [-Wincompatible-pointer-types]
  100 |         res = globus_xio_readv(xio_handle, &readv, 1, 1, &len, NULL);
      |                                                          ^~~~
      |                                                          |
      |                                                          int *
In file included from globus_ftp_telnet_client.c:17:
/usr/include/globus/globus_xio.h:776:41: note: expected ‘globus_size_t *’ {aka ‘long unsigned int *’} but argument is of type ‘int *’
  776 |     globus_size_t *                     nbytes,
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
make[3]: *** [Makefile:408: globus_ftp_telnet_client.o] Error 1
```
