### PR TITLE
CI: update potentially stale repo data before trying to install packages

### DIFF
--- a/travis-ci/run_task_inside_docker.sh
+++ b/travis-ci/run_task_inside_docker.sh
@@ -117,7 +117,8 @@ elif [[ $TASK == *rpms ]]; then
     packages+=(pam libedit libedit-devel)
 fi
 
-dnf --allowerasing -y -d1 install "${packages[@]}"
+# update potentially stale repo data before trying to install packages
+dnf --refresh --allowerasing -y -d1 install "${packages[@]}"
 
 # UID of travis user inside needs to match UID of travis user outside
 getent passwd travis > /dev/null || useradd travis -u $TRAVISUID -o


### PR DESCRIPTION
As per https://github.com/gridcf/gct/actions/runs/11596619308/job/32288101813?pr=232#step:4:155 there is currently an issue in the Rocky Linux 9 container that already showed two times now:

The repo data inside the container seems to be stale and not current with the actual repos for the package "python3-devel (at "3.9.18-3.el9_4.5")" and its dependencies. https://download.rockylinux.org/pub/rocky/9/AppStream/x86_64/os/Packages/p/ shows python3-devel at "3.9.18-3.el9_4.6" since "24-Oct-2024 18:30" making the tried-to-be-installed package out-of-date.

So let's update the repo data prior to installing packages.