### PR TITLE
Make OpenSSL engine optional

### DIFF
--- a/myproxy/source/certauth_extensions.c
+++ b/myproxy/source/certauth_extensions.c
@@ -4,7 +4,9 @@
  */
 
 #include "myproxy_common.h"
+#ifndef OPENSSL_NO_ENGINE
 #include <openssl/engine.h>
+#endif
 #include <openssl/ui.h>
 
 #define BUF_SIZE 16384
@@ -467,8 +469,10 @@ write_certificate(X509 *cert, const char serial[], const char dir[]) {
 }
 
 static EVP_PKEY  *e_cakey=NULL;
+#ifndef OPENSSL_NO_ENGINE
 static ENGINE    *engine=NULL;
 static int        engine_used=0;
+#endif
 
 static int 
 generate_certificate( X509_REQ                 *request, 
@@ -701,6 +705,7 @@ generate_certificate( X509_REQ                 *request,
 
   /* load ca key */
 
+#ifndef OPENSSL_NO_ENGINE
   if (engine) {
       if (server_context->certificate_openssl_engine_lockfile) {
           lockfd = open(server_context->certificate_openssl_engine_lockfile,
@@ -725,6 +730,7 @@ generate_certificate( X509_REQ                 *request,
           goto error;
       }
   }
+#endif
 
   if(e_cakey) {
       cakey = e_cakey;
@@ -770,6 +776,7 @@ generate_certificate( X509_REQ                 *request,
     goto error;
   } 
   serial = i2s_ASN1_OCTET_STRING(NULL, X509_get_serialNumber(cert));
+#ifndef OPENSSL_NO_ENGINE
   if (engine) {
       engine_used=1;
       if (lockfd != -1) close(lockfd);
@@ -779,6 +786,7 @@ generate_certificate( X509_REQ                 *request,
           goto error;
       }
   }
+#endif
 
   return_value = 0;
 
@@ -827,6 +835,7 @@ arraylen(char **options) {
   return c;
 }
 
+#ifndef OPENSSL_NO_ENGINE
 void shutdown_openssl_engine(void) {
   if (e_cakey) EVP_PKEY_free( e_cakey );
   if (engine) ENGINE_finish(engine);
@@ -837,6 +846,7 @@ void shutdown_openssl_engine(void) {
 
   if (engine_used) ENGINE_cleanup();
 }
+#endif
 
 static int ui_read_fn(UI *ui, UI_STRING *ui_string) {
     switch(UI_get_string_type(ui_string)) {
@@ -868,6 +878,7 @@ static int ui_write_fn(UI *ui, UI_STRING *ui_string) {
     return 1;
 }
 
+#ifndef OPENSSL_NO_ENGINE
 int initialise_openssl_engine(myproxy_server_context_t *server_context) {
     ENGINE *e;
     EVP_PKEY *cakey;
@@ -982,6 +993,7 @@ int initialise_openssl_engine(myproxy_server_context_t *server_context) {
 	UI_destroy_method(ui_method);
 	return 1;
 }
+#endif
 
 static int
 do_check(const char *callout, const X509_REQ *req, const X509 *cert)

--- a/myproxy/source/certauth_extensions.h
+++ b/myproxy/source/certauth_extensions.h
@@ -4,7 +4,9 @@
  *
  */
 
+#ifndef OPENSSL_NO_ENGINE
 int initialise_openssl_engine(myproxy_server_context_t *server_context);
+#endif
 
 int is_certificate_authority_configured(myproxy_server_context_t
                                         *server_context);

--- a/myproxy/source/configure.ac
+++ b/myproxy/source/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT([myproxy],[6.2.18])
+AC_INIT([myproxy],[6.2.19])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign])
 LT_INIT([dlopen win32-dll])

--- a/myproxy/source/myproxy_server.c
+++ b/myproxy/source/myproxy_server.c
@@ -287,10 +287,17 @@ main(int argc, char *argv[])
     }
 
     if(server_context->certificate_openssl_engine_id) {
+#ifndef OPENSSL_NO_ENGINE
         if(!initialise_openssl_engine(server_context)) {
             myproxy_log_verror();
             my_failure("Could not initialise OpenSSL engine.");
         }
+#else
+        myproxy_log("Openssl has no engine support.");
+        myproxy_log("Can not use certificate_openssl_engine_id option.");
+        myproxy_log("Exiting.");
+        exit(1);
+#endif
     }
 
     if (!server_context->run_as_daemon) {

--- a/packaging/debian/myproxy/debian/changelog.in
+++ b/packaging/debian/myproxy/debian/changelog.in
@@ -1,3 +1,9 @@
+myproxy (6.2.19-1+gct.@distro@) @distro@; urgency=medium
+
+  * Make OpenSSL engine optional
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Sat, 02 Nov 2024 08:58:37 +0100
+
 myproxy (6.2.18-1+gct.@distro@) @distro@; urgency=medium
 
   * Change private key cipher to EVP_aes_256_cbc

--- a/packaging/fedora/myproxy.spec
+++ b/packaging/fedora/myproxy.spec
@@ -2,7 +2,7 @@
 
 Name:           myproxy
 %global soname 6
-Version:        6.2.18
+Version:        6.2.19
 Release:        1%{?dist}
 Summary:        Manage X.509 Public Key Infrastructure (PKI) security credentials
 
@@ -391,6 +391,9 @@ fi
 %doc %{_pkgdocdir}/LICENSE*
 
 %changelog
+* Sat Nov 02 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.19-1
+- Make OpenSSL engine optional
+
 * Tue Jul 23 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.18-1
 - Change private key cipher to EVP_aes_256_cbc
 


### PR DESCRIPTION
OpenSSL in RHEL 10 has dropped the support for the ENGINE API.
This PR makes the use of the ENGINE API optional in myproxy. so that it can be compiled on RHEL+EPEL 10.
