### PR TITLE
Merge flags for OpenSSL 3.x versions.

### DIFF
--- a/gsi_openssh/source/configure.ac
+++ b/gsi_openssh/source/configure.ac
@@ -2903,12 +2903,8 @@ if test "x$openssl" = "xyes" ; then
 				;;
 			101*)   ;; # 1.1.x
 			200*)   ;; # LibreSSL
-			300*)
+			30*)
 				# OpenSSL 3; we use the 1.1x API
-				CPPFLAGS="$CPPFLAGS -DOPENSSL_API_COMPAT=0x10100000L"
-				;;
-			301*|302*)
-				# OpenSSL development branch; request 1.1x API
 				CPPFLAGS="$CPPFLAGS -DOPENSSL_API_COMPAT=0x10100000L"
 				;;
 		        *)


### PR DESCRIPTION
Taking over upstream openssh commit 2eded551ba96e66bc3afbbcc883812c2eac02bd7:

> OpenSSL has moved to 3.4 which we don't currently accept.  Based on the OpenSSL versioning policy[0] it looks like all of the 3.x versions should work with OpenSSH, so remove the distinction in configure and accept all of them.
> 
> [0] https://openssl.org/policies/general/versioning-policy.html

Fixes #235 