### PR TITLE
Fix compilation with GCC 15 (Fedora 42)

### DIFF
--- a/gridftp/server/src/configure.ac
+++ b/gridftp/server/src/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gridftp_server],[13.27],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gridftp_server],[13.28],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gridftp/server/src/globus_gridftp_server.h
+++ b/gridftp/server/src/globus_gridftp_server.h
@@ -2130,7 +2130,9 @@ typedef globus_result_t
     globus_gfs_brain_reason_t           reason);
 
 typedef globus_result_t
-(*globus_i_gfs_brain_init_func_t)();
+(*globus_i_gfs_brain_init_func_t)(
+    globus_callback_func_t              ready_cb,
+    void *                              ready_cb_arg);
 
 typedef void
 (*globus_i_gfs_brain_stop_func_t)();

--- a/gridftp/server/src/test/sharing_allowed_test.c
+++ b/gridftp/server/src/test/sharing_allowed_test.c
@@ -9,7 +9,10 @@
 
 #include "globus_i_gfs_data.c"
 
-extern int globus_i_gfs_config_init();
+extern int globus_i_gfs_config_init(
+    int                                 argc,
+    char **                             argv,
+    globus_bool_t                       argv_only);
 
 typedef struct
 {

--- a/gsi/credential/source/configure.ac
+++ b/gsi/credential/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gsi_credential],[8.4],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gsi_credential],[8.5],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])
@@ -29,6 +29,6 @@ AC_CONFIG_FILES(
         globus-gsi-credential.pc
         Makefile
         library/Doxyfile
-	library/Makefile
-	version.h)
+        library/Makefile
+        version.h)
 AC_OUTPUT

--- a/gsi/credential/source/library/globus_gsi_credential.c
+++ b/gsi/credential/source/library/globus_gsi_credential.c
@@ -977,7 +977,7 @@ globus_gsi_cred_read_proxy_bio(
 
                 goto exit;
             }
-            if (!PEM_do_header(&cipher, data, &len, (int (*) ()) globus_i_gsi_cred_password_callback_no_prompt, NULL))
+            if (!PEM_do_header(&cipher, data, &len, globus_i_gsi_cred_password_callback_no_prompt, NULL))
             {
                 GLOBUS_GSI_CRED_OPENSSL_ERROR_RESULT(
                     result,
@@ -1127,7 +1127,7 @@ globus_result_t
 globus_gsi_cred_read_key(
     globus_gsi_cred_handle_t            handle,
     const char *                        key_filename,
-    int                                 (*pw_cb)())
+    pem_password_cb *                   pw_cb)
 {
     BIO *                               key_bio = NULL;
     globus_result_t                     result;
@@ -2093,9 +2093,9 @@ int
 globus_i_gsi_cred_password_callback_no_prompt(
     char *                              buffer,
     int                                 size,
-    int                                 w)
+    int                                 w,
+    void *                              u)
 {
-
     GLOBUS_I_GSI_CRED_DEBUG_ENTER;
 
     /* current gsi implementation does not allow for a password

--- a/gsi/credential/source/library/globus_gsi_credential.h
+++ b/gsi/credential/source/library/globus_gsi_credential.h
@@ -212,7 +212,7 @@ globus_result_t globus_gsi_cred_read_proxy_bio(
 globus_result_t globus_gsi_cred_read_key(
     globus_gsi_cred_handle_t            handle,
     const char *                        key_filename,
-    int                                 (*pw_cb)());
+    pem_password_cb *                   pw_cb);
 
 globus_result_t globus_gsi_cred_read_cert(
     globus_gsi_cred_handle_t            handle,

--- a/gsi/credential/source/library/globus_i_gsi_credential.h
+++ b/gsi/credential/source/library/globus_i_gsi_credential.h
@@ -229,7 +229,8 @@ int
 globus_i_gsi_cred_password_callback_no_prompt(
     char *                              buffer,
     int                                 size,
-    int                                 w);
+    int                                 w,
+    void *                              u);
 
 globus_result_t
 globus_i_gsi_cred_openssl_error_result(

--- a/gsi/proxy/proxy_ssl/source/configure.ac
+++ b/gsi/proxy/proxy_ssl/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gsi_proxy_ssl], [6.5],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gsi_proxy_ssl], [6.6],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])
@@ -22,7 +22,7 @@ AC_CONFIG_FILES(
         Makefile
         globus-gsi-proxy-ssl.pc
         globus-gsi-proxy-ssl-uninstalled.pc
-	library/Makefile
+        library/Makefile
         library/Doxyfile
         test/Makefile
 )

--- a/gsi/proxy/proxy_ssl/source/library/proxycertinfo.h
+++ b/gsi/proxy/proxy_ssl/source/library/proxycertinfo.h
@@ -79,7 +79,7 @@ extern "C" {
 #define PROXYCERTINFO_SN                "PROXYCERTINFO"
 #define PROXYCERTINFO_LN                "Proxy Certificate Info Extension"
 #define PROXYCERTINFO_OLD_SN            "OLD_PROXYCERTINFO"
-#define PROXYCERTINFO_OLD_LN                "Proxy Certificate Info Extension (old OID)"
+#define PROXYCERTINFO_OLD_LN            "Proxy Certificate Info Extension (old OID)"
 
 /*
  * Used for error checking
@@ -138,13 +138,10 @@ DECLARE_ASN1_FUNCTIONS(PROXYCERTINFO)
 /* macros */
 
 #define d2i_PROXYCERTINFO_bio(bp, pci) \
-    (PROXYCERTINFO *) ASN1_d2i_bio((char *(*)()) PROXYCERTINFO_new, \
-    (char *(*)()) d2i_PROXYCERTINFO, \
-    (bp), (unsigned char **) pci)
+  ASN1_d2i_bio_of(PROXYCERTINFO, PROXYCERTINFO_new, d2i_PROXYCERTINFO, bp, pci)
 
 #define i2d_PROXYCERTINFO_bio(bp, pci) \
-                ASN1_i2d_bio(i2d_PROXYCERTINFO, bp, \
-		(unsigned char *)pci)
+  ASN1_i2d_bio_of(PROXYCERTINFO, i2d_PROXYCERTINFO, bp, pci)
 
 /* functions */
     

--- a/gsi/proxy/proxy_utils/source/configure.ac
+++ b/gsi/proxy/proxy_utils/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_proxy_utils],[7.3],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_proxy_utils],[7.4],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])
@@ -34,8 +34,8 @@ AC_CONFIG_FILES(
         globus-proxy-utils-uninstalled.pc
         globus-proxy-utils.pc
         Makefile
-	programs/Makefile
+        programs/Makefile
         test/Makefile
         test/testcred.cnf
-	version.h)
+        version.h)
 AC_OUTPUT

--- a/gsi/proxy/proxy_utils/source/programs/grid_proxy_init.c
+++ b/gsi/proxy/proxy_utils/source/programs/grid_proxy_init.c
@@ -126,7 +126,8 @@ static int
 globus_i_gsi_proxy_utils_pwstdin_callback(
     char *                              buf, 
     int                                 num, 
-    int                                 w);
+    int                                 w,
+    void *                              u);
 
 static void
 globus_i_gsi_proxy_utils_key_gen_callback(
@@ -174,7 +175,7 @@ main(
     char *                              policy_language = NULL;
     int                                 policy_NID;
     long                                path_length = -1;
-    int                                 (*pw_cb)() = NULL;
+    pem_password_cb *                   pw_cb = NULL;
     int                                 return_value = 0;
     
     if(globus_module_activate(GLOBUS_GSI_PROXY_MODULE) != (int)GLOBUS_SUCCESS)
@@ -1070,7 +1071,8 @@ static int
 globus_i_gsi_proxy_utils_pwstdin_callback(
     char *                              buf, 
     int                                 num, 
-    int                                 w)
+    int                                 w,
+    void *                              u)
 {
     int                                 i;
 

--- a/myproxy/source/certauth_extensions.c
+++ b/myproxy/source/certauth_extensions.c
@@ -1158,7 +1158,7 @@ handle_certificate(unsigned char            *input_buffer,
   } 
 
   /* convert pkey into string for output to log */
-  ASN1_digest((int (*)())i2d_PUBKEY,EVP_sha1(),(char*)pkey,md,&md_len);
+  ASN1_digest((i2d_of_void*)i2d_PUBKEY, EVP_sha1(), (char*)pkey, md, &md_len);
   sub_hash = md[0] + (md[1] + (md[2] + (md[3] >> 1) * 256) * 256) * 256; 
 
   myproxy_log("Got a cert request for user \"%s\", "

--- a/myproxy/source/configure.ac
+++ b/myproxy/source/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT([myproxy],[6.2.19])
+AC_INIT([myproxy],[6.2.20])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign])
 LT_INIT([dlopen win32-dll])

--- a/myproxy/source/gsi_socket.c
+++ b/myproxy/source/gsi_socket.c
@@ -1031,7 +1031,7 @@ GSI_SOCKET_get_peer_fqans(GSI_SOCKET *self, char ***fqans)
 {
     static int once = 1;
     static void *myproxy_voms_handle = 0;
-    static int (*myproxy_voms_get_peer_fqans)() = 0;
+    static int (*myproxy_voms_get_peer_fqans)(GSI_SOCKET *, char ***) = 0;
 
     if (once)
     {

--- a/myproxy/source/myproxy_server.c
+++ b/myproxy/source/myproxy_server.c
@@ -15,7 +15,11 @@
 #endif
 
 int have_voms = 0;
-void (*get_voms_proxy_impl)();
+void (*get_voms_proxy_impl)(myproxy_socket_attrs_t *,
+                            myproxy_creds_t *,
+                            myproxy_request_t *,
+                            myproxy_response_t *,
+                            myproxy_server_context_t *);
 
 static char usage[] = \
 "\n"\

--- a/myproxy/source/ssl_utils.c
+++ b/myproxy/source/ssl_utils.c
@@ -824,7 +824,7 @@ ssl_private_key_store_to_file(SSL_CREDENTIALS *creds,
        uses PEM_write_bio_PKCS8PrivateKey() which "uses the more more secure
        PKCS#8 private key format with a high iteration count" per the CHANGES
        file in the openssl tree */
-    if (PEM_ASN1_write_bio((int (*)())i2d_PrivateKey,
+    if (PEM_ASN1_write_bio((i2d_of_void *) i2d_PrivateKey,
                            ((EVP_PKEY_id(creds->private_key) == EVP_PKEY_DSA)?
                            PEM_STRING_DSA:PEM_STRING_RSA),
                            keybio, (void *)creds->private_key, cipher,
@@ -1142,7 +1142,7 @@ ssl_proxy_to_pem(SSL_CREDENTIALS                *creds,
        uses PEM_write_bio_PKCS8PrivateKey() which "uses the more more secure
        PKCS#8 private key format with a high iteration count" per the CHANGES
        file in the openssl tree */
-    if (PEM_ASN1_write_bio((int (*)())i2d_PrivateKey,
+    if (PEM_ASN1_write_bio((i2d_of_void *) i2d_PrivateKey,
                            ((EVP_PKEY_id(creds->private_key) == EVP_PKEY_DSA)?
                            PEM_STRING_DSA:PEM_STRING_RSA),
                            bio, (void *)creds->private_key, cipher,

--- a/packaging/debian/globus-gridftp-server/debian/changelog.in
+++ b/packaging/debian/globus-gridftp-server/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gridftp-server (13.28-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix incompatible pointer errors (gcc 15)
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 17 Jan 2025 09:04:59 +0100
+
 globus-gridftp-server (13.27-1+gct.@distro@) @distro@; urgency=medium
 
   * Handle 64 bit time_t on 32 bit systems

--- a/packaging/debian/globus-gsi-credential/debian/changelog.in
+++ b/packaging/debian/globus-gsi-credential/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gsi-credential (8.5-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix incompatible pointer errors (gcc 15)
+
+ -- Mischa Sallé <msalle@nikhef.nl>  Fri, 17 Jan 2025 09:06:35 +0100
+
 globus-gsi-credential (8.4-1+gct.@distro@) @distro@; urgency=medium
 
   * Greatly simplify getting current time

--- a/packaging/debian/globus-gsi-proxy-ssl/debian/changelog.in
+++ b/packaging/debian/globus-gsi-proxy-ssl/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gsi-proxy-ssl (6.6-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix incompatible pointer errors (gcc 15)
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 17 Jan 2025 09:07:46 +0100
+
 globus-gsi-proxy-ssl (6.5-1+gct.@distro@) @distro@; urgency=medium
 
   * Fixes for OpenSSL-3.0.0-beta1

--- a/packaging/debian/globus-proxy-utils/debian/changelog.in
+++ b/packaging/debian/globus-proxy-utils/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-proxy-utils (7.4-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix incompatible pointer errors (gcc 15)
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 17 Jan 2025 09:08:49 +0100
+
 globus-proxy-utils (7.3-1+gct.@distro@) @distro@; urgency=medium
 
   * Use sha256 hash when generating test certificates

--- a/packaging/debian/myproxy/debian/changelog.in
+++ b/packaging/debian/myproxy/debian/changelog.in
@@ -1,3 +1,9 @@
+myproxy (6.2.20-1+gct.@distro@) @distro@; urgency=medium
+
+  * Fix incompatible pointer errors (gcc 15)
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Fri, 17 Jan 2025 09:10:05 +0100
+
 myproxy (6.2.19-1+gct.@distro@) @distro@; urgency=medium
 
   * Make OpenSSL engine optional

--- a/packaging/fedora/globus-gridftp-server.spec
+++ b/packaging/fedora/globus-gridftp-server.spec
@@ -3,7 +3,7 @@
 Name:		globus-gridftp-server
 %global soname 6
 %global _name %(echo %{name} | tr - _)
-Version:	13.27
+Version:	13.28
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GridFTP Server
 
@@ -223,6 +223,9 @@ fi
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Fri Jan 17 2025 Mattias Ellert <mattias.ellert@physics.uu.se> - 13.28-1
+- Fix incompatible pointer errors (gcc 15)
+
 * Sat Mar 16 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 13.27-1
 - Handle 64 bit time_t on 32 bit systems
 

--- a/packaging/fedora/globus-gsi-credential.spec
+++ b/packaging/fedora/globus-gsi-credential.spec
@@ -3,7 +3,7 @@
 Name:		globus-gsi-credential
 %global soname 1
 %global _name %(echo %{name} | tr - _)
-Version:	8.4
+Version:	8.5
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Credential Library
 
@@ -137,6 +137,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.la
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Fri Jan 17 2025 Mattias Ellert <mattias.ellert@physics.uu.se> - 8.5-1
+- Fix incompatible pointer errors (gcc 15)
+
 * Thu Jan 19 2023 Mischa Salle <msalle@nikhef.nl> - 8.4-1
 - Greatly simplify getting current time
 

--- a/packaging/fedora/globus-gsi-proxy-ssl.spec
+++ b/packaging/fedora/globus-gsi-proxy-ssl.spec
@@ -3,7 +3,7 @@
 Name:		globus-gsi-proxy-ssl
 %global soname 1
 %global _name %(echo %{name} | tr - _)
-Version:	6.5
+Version:	6.6
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Proxy SSL Library
 
@@ -142,6 +142,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Fri Jan 17 2025 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.6-1
+- Fix incompatible pointer errors (gcc 15)
+
 * Tue Jul 20 2021 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.5-1
 - Fixes for OpenSSL-3.0.0-beta1
 

--- a/packaging/fedora/globus-proxy-utils.spec
+++ b/packaging/fedora/globus-proxy-utils.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-proxy-utils
 %global _name %(echo %{name} | tr - _)
-Version:	7.3
+Version:	7.4
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - Globus GSI Proxy Utility Programs
 
@@ -77,6 +77,9 @@ make %{?_smp_mflags} check VERBOSE=1
 %doc %{_pkgdocdir}/GLOBUS_LICENSE
 
 %changelog
+* Fri Jan 17 2025 Mattias Ellert <mattias.ellert@physics.uu.se> - 7.4-1
+- Fix incompatible pointer errors (gcc 15)
+
 * Sun Mar 06 2022 Mattias Ellert <mattias.ellert@physics.uu.se> - 7.3-1
 - Use sha256 hash when generating test certificates
 

--- a/packaging/fedora/myproxy.spec
+++ b/packaging/fedora/myproxy.spec
@@ -2,7 +2,7 @@
 
 Name:           myproxy
 %global soname 6
-Version:        6.2.19
+Version:        6.2.20
 Release:        1%{?dist}
 Summary:        Manage X.509 Public Key Infrastructure (PKI) security credentials
 
@@ -391,6 +391,9 @@ fi
 %doc %{_pkgdocdir}/LICENSE*
 
 %changelog
+* Fri Jan 17 2025 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.20-1
+- Fix incompatible pointer errors (gcc 15)
+
 * Sat Nov 02 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 6.2.19-1
 - Make OpenSSL engine optional
 


### PR DESCRIPTION
GCC 15 has improved diagnostics and detects more incompatible pointer type errors than earlier versions. Especially function pointers being assigned pointers to function with the wrong type and/or number of arguments are better detected.

This commit fixes the compilation with GCC 15 on Fedora 42.