### PR TITLE
Only check write permission for stdout/stderr if path is absolute

### DIFF
--- a/gram/jobmanager/source/configure.ac
+++ b/gram/jobmanager/source/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.60])
 
-AC_INIT([globus_gram_job_manager],[15.9],[https://github.com/gridcf/gct/issues])
+AC_INIT([globus_gram_job_manager],[15.10],[https://github.com/gridcf/gct/issues])
 AC_CONFIG_MACRO_DIR([m4])
 AC_SUBST([MAJOR_VERSION], [${PACKAGE_VERSION%%.*}])
 AC_SUBST([MINOR_VERSION], [${PACKAGE_VERSION##*.}])

--- a/gram/jobmanager/source/globus_gram_job_manager_staging.c
+++ b/gram/jobmanager/source/globus_gram_job_manager_staging.c
@@ -311,9 +311,11 @@ globus_l_staging_replace_one_stream(
             goto bad_value;
         }
     }
-    else if (strstr(evaled_to, "://") == NULL)
+    else if (strstr(evaled_to, "://") == NULL && evaled_to[0] == '/')
     {
-        /* If it's a local file, check that it is writable */
+        /* If it's a local file with absolute path, check that it is
+         * writable
+         */
         int tmpfd;
 
         tmpfd = open(evaled_to, O_WRONLY|O_CREAT|O_APPEND, S_IRUSR|S_IWUSR);

--- a/packaging/debian/globus-gram-job-manager/debian/changelog.in
+++ b/packaging/debian/globus-gram-job-manager/debian/changelog.in
@@ -1,3 +1,9 @@
+globus-gram-job-manager (15.10-1+gct.@distro@) @distro@; urgency=medium
+
+  * Only check write permission for stdout/stderr if path is absolute
+
+ -- Mattias Ellert <mattias.ellert@physics.uu.se>  Sat, 26 Apr 2025 05:04:03 +0200
+
 globus-gram-job-manager (15.9-1+gct.@distro@) @distro@; urgency=medium
 
   * Handle 64 bit time_t on 32 bit systems

--- a/packaging/fedora/globus-gram-job-manager.spec
+++ b/packaging/fedora/globus-gram-job-manager.spec
@@ -2,7 +2,7 @@
 
 Name:		globus-gram-job-manager
 %global _name %(echo %{name} | tr - _)
-Version:	15.9
+Version:	15.10
 Release:	1%{?dist}
 Summary:	Grid Community Toolkit - GRAM Jobmanager
 
@@ -169,6 +169,9 @@ GLOBUS_HOSTNAME=localhost make %{?_smp_mflags} check VERBOSE=1
 %{_libdir}/libglobus_seg_job_manager.so
 
 %changelog
+* Sat Apr 26 2025 Mattias Ellert <mattias.ellert@physics.uu.se> - 15.10-1
+- Only check write permission for stdout/stderr if path is absolute
+
 * Fri Mar 01 2024 Mattias Ellert <mattias.ellert@physics.uu.se> - 15.9-1
 - Handle 64 bit time_t on 32 bit systems
 


### PR DESCRIPTION
For relative paths stdout/stderr are relative to the job's working directory which is writable, so the check is redundant.

The current check instead tests if the user's home directory is writable which is irrelevant. The test also creates and leaves behind a zero-length file in the user's home directory. The test also gives false failures if the user's home directory is not writable.

Fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1103552