### PR TITLE
Fix CVE-2026-3497

### DIFF
--- a/gsi_openssh/source/kexgssc.c
+++ b/gsi_openssh/source/kexgssc.c
@@ -125,7 +125,7 @@ kexgss_final(struct ssh *ssh)
 
 	/* Verify that the hash matches the MIC we just got. */
 	if (GSS_ERROR(ssh_gssapi_checkmic(gss, &gss->buf, &gss->msg_tok)))
-		sshpkt_disconnect(ssh, "Hash's MIC didn't verify");
+		ssh_packet_disconnect(ssh, "Hash's MIC didn't verify");
 
 	gss_release_buffer(&gss->minor, &gss->msg_tok);
 
@@ -348,10 +348,10 @@ input_kexgss_complete(int type,
 			fatal("Failed to read token: %s", ssh_err(r));
 		/* If we're already complete - protocol error */
 		if (gss->major == GSS_S_COMPLETE)
-			sshpkt_disconnect(ssh, "Protocol error: received token when complete");
+			ssh_packet_disconnect(ssh, "Protocol error: received token when complete");
 	} else {
 		if (gss->major != GSS_S_COMPLETE)
-			sshpkt_disconnect(ssh, "Protocol error: did not receive final token");
+			ssh_packet_disconnect(ssh, "Protocol error: did not receive final token");
 	}
 	if ((r = sshpkt_get_end(ssh)) != 0)
 		fatal("Expecting end of packet.");
@@ -487,7 +487,7 @@ kexgssgex_final(struct ssh *ssh)
 
 	/* Verify that the hash matches the MIC we just got. */
 	if (GSS_ERROR(ssh_gssapi_checkmic(gss, &gss->buf, &gss->msg_tok)))
-		sshpkt_disconnect(ssh, "Hash's MIC didn't verify");
+		ssh_packet_disconnect(ssh, "Hash's MIC didn't verify");
 
 	gss_release_buffer(&gss->minor, &gss->msg_tok);
 
@@ -688,10 +688,10 @@ input_kexgssgex_complete(int type,
 			fatal("Failed to read token: %s", ssh_err(r));
 		/* If we're already complete - protocol error */
 		if (gss->major == GSS_S_COMPLETE)
-			sshpkt_disconnect(ssh, "Protocol error: received token when complete");
+			ssh_packet_disconnect(ssh, "Protocol error: received token when complete");
 	} else {
 		if (gss->major != GSS_S_COMPLETE)
-			sshpkt_disconnect(ssh, "Protocol error: did not receive final token");
+			ssh_packet_disconnect(ssh, "Protocol error: did not receive final token");
 	}
 	if ((r = sshpkt_get_end(ssh)) != 0)
 		fatal("Expecting end of packet.");

--- a/gsi_openssh/source/kexgsss.c
+++ b/gsi_openssh/source/kexgsss.c
@@ -132,7 +132,7 @@ kexgss_final(struct ssh *ssh,
 {
 	struct kex *kex = ssh->kex;
 	Gssctxt *gss = kex->gss;
-	gss_buffer_desc msg_tok;
+	gss_buffer_desc msg_tok = GSS_C_EMPTY_BUFFER;;
 	u_char hash[SSH_DIGEST_MAX_LENGTH];
 	size_t hashlen;
 	struct sshbuf *shared_secret = NULL;
@@ -217,7 +217,8 @@ input_kexgss_init(int type,
 	Gssctxt *gss = kex->gss;
 	struct sshbuf *empty;
 	struct sshbuf *client_pubkey = NULL;
-	gss_buffer_desc recv_tok, send_tok = GSS_C_EMPTY_BUFFER;
+	gss_buffer_desc recv_tok = GSS_C_EMPTY_BUFFER;
+	gss_buffer_desc send_tok = GSS_C_EMPTY_BUFFER;
 	OM_uint32 ret_flags = 0;
 	int r;
 
@@ -293,7 +294,8 @@ input_kexgss_continue(int type,
 		      struct ssh *ssh)
 {
 	Gssctxt *gss = ssh->kex->gss;
-	gss_buffer_desc recv_tok, send_tok = GSS_C_EMPTY_BUFFER;
+	gss_buffer_desc recv_tok = GSS_C_EMPTY_BUFFER;
+	gss_buffer_desc send_tok = GSS_C_EMPTY_BUFFER;
 	OM_uint32 ret_flags = 0;
 	int r;
 
@@ -384,7 +386,7 @@ kexgssgex_final(struct ssh *ssh,
 {
 	struct kex *kex = ssh->kex;
 	Gssctxt *gss = kex->gss;
-	gss_buffer_desc msg_tok;
+	gss_buffer_desc msg_tok = GSS_C_EMPTY_BUFFER;;
 	u_char hash[SSH_DIGEST_MAX_LENGTH];
 	size_t hashlen;
 	const BIGNUM *pub_key, *dh_p, *dh_g;
@@ -526,8 +528,7 @@ input_kexgssgex_groupreq(int type,
 
 	kex->dh = mm_choose_dh(min, nbits, max);
 	if (kex->dh == NULL) {
-		sshpkt_disconnect(ssh, "Protocol error: no matching group found");
-		fatal("Protocol error: no matching group found");
+		ssh_packet_disconnect(ssh, "Protocol error: no matching group found");
 	}
 
 	DH_get0_pqg(kex->dh, &dh_p, NULL, &dh_g);
@@ -560,7 +561,8 @@ input_kexgssgex_init(int type,
 		     struct ssh *ssh)
 {
 	Gssctxt *gss = ssh->kex->gss;
-	gss_buffer_desc recv_tok, send_tok = GSS_C_EMPTY_BUFFER;
+	gss_buffer_desc recv_tok = GSS_C_EMPTY_BUFFER;
+	gss_buffer_desc send_tok = GSS_C_EMPTY_BUFFER;
 	OM_uint32 ret_flags = 0;
 	int r;
 
@@ -587,7 +589,8 @@ input_kexgssgex_continue(int type,
 			 struct ssh *ssh)
 {
 	Gssctxt *gss = ssh->kex->gss;
-	gss_buffer_desc recv_tok, send_tok = GSS_C_EMPTY_BUFFER;
+	gss_buffer_desc recv_tok = GSS_C_EMPTY_BUFFER;
+	gss_buffer_desc send_tok = GSS_C_EMPTY_BUFFER;
 	OM_uint32 ret_flags = 0;
 	int r;
 


### PR DESCRIPTION
Fix information disclosure or denial of service due to uninitialized variables in gssapi-keyex

Based on https://src.fedoraproject.org/rpms/openssh/c/f595270c4ac496ad743336e80a4f3cc11a144efb?branch=rawhide by Zoltan Fridrich <zfridric@redhat.com>